### PR TITLE
Genre model and pytest config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@
 
 - django
 - djangorestframework
+- pytest
+- pytest-django
 
 ### Belangrijke commands:
 
-- start de dev server: python manage.py runserver
-- migrations aanmaken voor X: python manage.py makemigrations X
-    -- bv. python manage.py makemigrations languages
-- migrate: python manage.py migrate
+- start de dev server: ```python manage.py runserver```
+- migrations aanmaken voor X: ```python manage.py makemigrations X```
+    -- bv. ```python manage.py makemigrations languages```
+- migrate: ```python manage.py migrate```
 
 ---

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -3,3 +3,4 @@ venv
 
 *__pycache__
 *migrations
+.pytest_cache

--- a/backend/apps/genres/admin.py
+++ b/backend/apps/genres/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/backend/apps/genres/models.py
+++ b/backend/apps/genres/models.py
@@ -1,0 +1,82 @@
+from django.db import models
+from apps.core.model import BaseModel
+from apps.languages.models import Language
+
+class GenreUseAs(BaseModel):
+    name = models.CharField(
+        max_length=50,
+        null=False,
+        blank=False,
+        db_comment="Use cases for the genre, ex. 'tag', 'genre'"
+    )
+
+    class Meta(BaseModel.Meta):
+        db_table = "genre_use_as"
+        verbose_name = "Genre Use As"
+        verbose_name_plural = "Genres Used As"
+
+class Genre(BaseModel):
+    type = models.CharField(
+        max_length=50,
+        null=False,
+        blank=False,
+        db_comment="The type of the genre ex. 'Theater', 'Festival', 'Boek voorstelling', etc."
+    )
+
+    use_as = models.ForeignKey(
+        GenreUseAs,
+        on_delete=models.CASCADE,
+        related_name="genres", 
+        null=False,
+        blank=False,
+        db_comment="Reference to GenreUseAs."
+    )
+
+    class Meta(BaseModel.Meta):
+        db_table = "genre"
+        verbose_name = "Genre"
+        verbose_name_plural = "Genres"
+
+    def __str__(self):
+        english_name = GenreTranslation.objects.filter(
+            genre=self,
+            language_id="en"
+        )
+
+        dutch_name = GenreTranslation.objects.filter(
+            genre=self,
+            language_id="nl"
+        )
+
+        return f"{self.type} - {str(english_name)} - {str(dutch_name)}"
+
+
+class GenreTranslation(BaseModel):
+    name = models.CharField(
+        max_length=50,
+        null=False,
+        blank=False,
+        db_comment="The name of the genre in a specific language"
+    )
+
+    language = models.ForeignKey(
+        Language,
+        on_delete=models.CASCADE,
+        related_name="genre_translations",
+        db_comment="Reference to the language of the genre translation."
+    )
+
+    genre = models.ForeignKey(
+        Genre,
+        on_delete=models.CASCADE,
+        related_name="genre_translations",
+        db_comment="Reference to the genre."
+    )
+
+    class Meta(BaseModel.Meta):
+        db_table = "genre_translation"
+        verbose_name = "Genre Translation"
+        verbose_name_plural = "Genre Translations"
+    
+    def __str__(self) -> str:
+        return f"{self.language.code} - {self.name}"

--- a/backend/apps/genres/models.py
+++ b/backend/apps/genres/models.py
@@ -1,8 +1,15 @@
+"""
+Definitions of the models related to genres.
+"""
+
 from django.db import models
 from apps.core.model import BaseModel
 from apps.languages.models import Language
 
 class GenreUseAs(BaseModel):
+    """
+    Model to define the use cases for genres. Like used in the existing viernulvier API.
+    """
     name = models.CharField(
         max_length=50,
         null=False,
@@ -15,7 +22,11 @@ class GenreUseAs(BaseModel):
         verbose_name = "Genre Use As"
         verbose_name_plural = "Genres Used As"
 
+
 class Genre(BaseModel):
+    """
+    Model to define genres.
+    """
     type = models.CharField(
         max_length=50,
         null=False,
@@ -38,20 +49,26 @@ class Genre(BaseModel):
         verbose_name_plural = "Genres"
 
     def __str__(self):
+        # Get the English name for the genre
         english_name = GenreTranslation.objects.filter(
             genre=self,
             language_id="en"
-        )
+        ).first()
 
+        # Get the Dutch name for the genre
         dutch_name = GenreTranslation.objects.filter(
             genre=self,
             language_id="nl"
-        )
+        ).first()
 
-        return f"{self.type} - {str(english_name)} - {str(dutch_name)}"
+        # Show both translations in the string representation of the genre
+        return f"{self.type} - [{str(english_name)}] - [{str(dutch_name)}]"
 
 
 class GenreTranslation(BaseModel):
+    """
+    Model to define different translations for genre names.
+    """
     name = models.CharField(
         max_length=50,
         null=False,

--- a/backend/apps/genres/views.py
+++ b/backend/apps/genres/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'apps.core',
     'apps.languages',
+    'apps.genres'
 ]
 
 MIDDLEWARE = [

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = config.settings
+python_files = tests.py test_*.py *_tests.py

--- a/backend/tests/genres/test_models.py
+++ b/backend/tests/genres/test_models.py
@@ -1,0 +1,128 @@
+"""
+Test file for Genre related models
+"""
+import pytest
+from django.core.exceptions import ValidationError
+
+from apps.genres.models import Genre, GenreTranslation, GenreUseAs
+from apps.languages.models import Language
+
+
+@pytest.mark.django_db
+def test_genre_use_as_requires_name() -> None:
+    """Ensure GenreUseAs validation rejects an empty name."""
+    with pytest.raises(ValidationError):
+        GenreUseAs(name="").save()
+
+
+@pytest.mark.django_db
+def test_genre_requires_use_as() -> None:
+    """Ensure a Genre cannot be saved without a GenreUseAs relation."""
+    with pytest.raises(ValidationError):
+        Genre(type="Rock", use_as=None).save()
+
+
+@pytest.mark.django_db
+def test_genre_translation_str() -> None:
+    """Verify GenreTranslation.__str__ returns '<language code> - <name>'."""
+    language = Language.objects.create(code="en", name="English", is_active=True)
+    use_as = GenreUseAs.objects.create(name="tag")
+    genre = Genre.objects.create(type="Rock", use_as=use_as)
+
+    translation = GenreTranslation.objects.create(
+        name="Rock",
+        language=language,
+        genre=genre,
+    )
+
+    assert str(translation) == "en - Rock"
+
+
+@pytest.mark.django_db
+def test_deleting_genre_use_as_cascades_to_genre() -> None:
+    """Verify deleting GenreUseAs cascades and removes related Genre records."""
+    use_as = GenreUseAs.objects.create(name="tag")
+    Genre.objects.create(type="Rock", use_as=use_as)
+
+    use_as.delete()
+
+    assert Genre.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_deleting_language_cascades_to_genre_translation() -> None:
+    """Verify deleting Language cascades and removes related GenreTranslation records."""
+    language = Language.objects.create(code="nl", name="Dutch", is_active=True)
+    use_as = GenreUseAs.objects.create(name="genre")
+    genre = Genre.objects.create(type="Theater", use_as=use_as)
+    GenreTranslation.objects.create(name="Theater", language=language, genre=genre)
+
+    language.delete()
+
+    assert GenreTranslation.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_genre_str() -> None:
+    """Ensure Genre.__str__ includes is correct."""
+    use_as = GenreUseAs.objects.create(name="tag")
+    genre = Genre.objects.create(type="Festival", use_as=use_as)
+    english = Language.objects.create(code="en", name="English", is_active=True)
+    dutch = Language.objects.create(code="nl", name="Dutch", is_active=True)
+
+    GenreTranslation.objects.create(name="Festival", language=english, genre=genre)
+    GenreTranslation.objects.create(name="Festival NL", language=dutch, genre=genre)
+
+    result = str(genre)
+
+    assert "Festival - [en - Festival] - [nl - Festival NL]" in result
+
+@pytest.mark.django_db
+def test_genre_has_multiple_translations() -> None:
+    """Ensure a Genre can have multiple related GenreTranslation entries."""
+    language_en = Language.objects.create(code="en", name="English", is_active=True)
+    language_nl = Language.objects.create(code="nl", name="Dutch", is_active=True)
+
+    use_as = GenreUseAs.objects.create(name="genre")
+    genre = Genre.objects.create(type="Theater", use_as=use_as)
+
+    GenreTranslation.objects.create(name="Theater", language=language_en, genre=genre)
+    GenreTranslation.objects.create(name="Theater NL", language=language_nl, genre=genre)
+
+    translations = genre.genre_translations.all()
+
+    assert translations.count() == 2
+
+@pytest.mark.django_db
+def test_language_has_related_genre_translations() -> None:
+    """Ensure Language exposes related GenreTranslation records via related_name."""
+    language = Language.objects.create(code="fr", name="French", is_active=True)
+    use_as = GenreUseAs.objects.create(name="tag")
+    genre = Genre.objects.create(type="Dance", use_as=use_as)
+
+    GenreTranslation.objects.create(name="Danse", language=language, genre=genre)
+
+    assert language.genre_translations.count() == 1
+
+@pytest.mark.django_db
+def test_genre_use_as_has_related_genres() -> None:
+    """Ensure GenreUseAs exposes related Genre records via related_name."""
+    use_as = GenreUseAs.objects.create(name="tag")
+    Genre.objects.create(type="Rock", use_as=use_as)
+    Genre.objects.create(type="Jazz", use_as=use_as)
+
+    assert use_as.genres.count() == 2
+
+
+@pytest.mark.django_db
+def test_deleting_genre_cascades_to_translations() -> None:
+    """Verify deleting Genre cascades and removes its GenreTranslation records."""
+    language = Language.objects.create(code="en", name="English", is_active=True)
+    use_as = GenreUseAs.objects.create(name="genre")
+    genre = Genre.objects.create(type="Opera", use_as=use_as)
+
+    GenreTranslation.objects.create(name="Opera", language=language, genre=genre)
+
+    genre.delete()
+
+    assert GenreTranslation.objects.count() == 0


### PR DESCRIPTION
## Genre related models

This issue implements the 3 genre related models (_GenreUsAs_, _Genre_, _GenreTranslation_) in ```backend/genres/models.py```.

These models are the link between our database and the API, by creating and running the migrations, django will create the related tables.

The commands for generating and running the migrations are:

```bash
python manage.py makemigrations genres
python manage.py migrate
```
(**Note:** This can also be found in the README for future reference)

Make sure you run these commands while in the ```backend``` folder.

## Tests

For testing we are using pytest. The ```backend/pytest.ini``` file is pretty straightforward, it contains a reference to our settings and also defines which files it will run for testing.

If you make your own tests **make sure that the file follows the test_*.py naming convention**.

We require two packages for testing in the backend. So make sure if you test locally you have the following packages installed:

- pytest
- pytest-django

The folder structure for tests should be the same structure as found in ```backend/apps```.  For example, the genre models are defined in ```backend/apps/genres/models.py``` so our tests for these models should be implemented in the file ```backend/tests/genres/test_models.py```

This structure is nice to have, because every resource will have a few corresponding files:

- models.py for defining the models 
- serializer.py for defining  the json serializer
- admin.py for the admin page
- ...

With the current file structure, everything relating a resource can quickly be found together. 

## Discussion

I am unsure about using cascade deletion for the foreign keys. This is used in the Genre and GenreTranslation models:

```python
class Genre(BaseModel):
...
use_as = models.ForeignKey(
        GenreUseAs,
        on_delete=models.CASCADE,
```

```python
class GenreTranslation(BaseModel):
...
language = models.ForeignKey(
        Language,
        on_delete=models.CASCADE,
        ...
    )

    genre = models.ForeignKey(
        Genre,
        on_delete=models.CASCADE,
        ...
    )
...
```

I think it's useful because of someone deletes a language, I think it's logical that all the translations for that language are also deleted. The same counts that if a Genre is deleted, the translation for that genre can also be deleted.

The problem is that it is not very safe, accidents can happen and maybe somehow a language would accidentally be deleted which would cause a lot of data loss...

Do you think that it's ok to use Cascade for these 3?