### PR TITLE
36 media library data layer implementation

### DIFF
--- a/backend/apps/media_library/admin.py
+++ b/backend/apps/media_library/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/backend/apps/media_library/models.py
+++ b/backend/apps/media_library/models.py
@@ -1,0 +1,144 @@
+from django.db import models
+from apps.core.model import BaseModel
+from apps.languages.models import Language
+
+class MediaGallery(BaseModel):
+    """Model representing a media gallery."""
+    name = models.CharField(
+        max_length=255,
+        db_comment="Name of the media gallery.",
+    )
+
+    class Meta(BaseModel.Meta):
+        db_table = "media_gallery"
+        verbose_name = "Media Gallery"
+        verbose_name_plural = "Media Galleries"
+    
+    def __str__(self):
+        return self.name
+    
+class MediaItem(BaseModel):
+    """Model representing a media item."""
+    gallery = models.ForeignKey(
+        MediaGallery,
+        on_delete=models.CASCADE,
+        related_name="media_items",
+        db_comment="The media gallery this item belongs to.",
+    )
+
+    type = models.CharField(
+        max_length=50,
+        db_comment="Type of media item (e.g., image, video).",
+    )
+
+    format = models.CharField(
+        max_length=50,
+        blank=True,
+        db_comment="Format of the media item (e.g., jpg, mp4).",
+    )
+
+    original_filename = models.CharField(
+        max_length=255,
+        blank=True,
+        db_comment="Original filename of the media item.",
+    )
+
+    position = models.PositiveIntegerField(
+        default=0,
+        db_comment="Position of the media item within the gallery.",
+    )
+
+    width = models.PositiveIntegerField(
+        null=True,
+        blank=True,
+        db_comment="Width of the media item in pixels.",
+    )
+
+    height = models.PositiveIntegerField(
+        null=True,
+        blank=True,
+        db_comment="Height of the media item in pixels.",
+    )
+
+    class Meta(BaseModel.Meta):
+        db_table = "media_item"
+        verbose_name = "Media Item"
+        verbose_name_plural = "Media Items"
+        ordering = ['position']
+
+    def __str__(self):
+        return f"{self.type} - {self.original_filename or 'Unnamed'}"
+    
+class MediaItemTranslation(BaseModel):
+    """Model representing a translation for a media item."""
+    media_item = models.ForeignKey(
+        MediaItem,
+        on_delete=models.CASCADE,
+        related_name="translations",
+        db_comment="The media item this translation belongs to.",
+    )
+
+    language = models.ForeignKey(
+        Language,
+        on_delete=models.CASCADE,
+        related_name="media_item_translations",
+        db_comment="Language of the translation.",
+    )
+
+    title = models.CharField(
+        max_length=255,
+        blank=True,
+        db_comment="Title of the media item in the specified language.",
+    )
+
+    description = models.TextField(
+        blank=True,
+        db_comment="Description of the media item in the specified language.",
+    )
+
+    credits = models.CharField(
+        max_length=255,
+        blank=True,
+        db_comment="Credits for the media item in the specified language.",
+    )
+
+    link = models.URLField(
+        blank=True,
+        db_comment="External link related to the media item in the specified language.",
+    )
+
+    class Meta(BaseModel.Meta):
+        db_table = "media_item_translation"
+        unique_together = (("media_item", "language"),)
+        verbose_name = "Media Item Translation"
+        verbose_name_plural = "Media Item Translations"
+    
+    def __str__(self):
+        return f"{self.media_item} - {self.language}"
+    
+class MediaItemCrop(BaseModel):
+    """Model representing a crop for a media item."""
+    media_item = models.ForeignKey(
+        MediaItem,
+        on_delete=models.CASCADE,
+        related_name="crops",
+        db_comment="The media item this crop belongs to.",
+    )
+
+    name = models.CharField(
+        max_length=100,
+        db_comment="Name of the crop (e.g., thumbnail, banner).",
+    )
+
+    url = models.URLField(
+        db_comment="URL of the cropped media item.",
+    )
+
+    class Meta(BaseModel.Meta):
+        db_table = "media_item_crop"
+        unique_together = (("media_item", "name"),)
+        verbose_name = "Media Item Crop"
+        verbose_name_plural = "Media Item Crops"
+    
+    def __str__(self):
+        return f"{self.media_item} - {self.name}"

--- a/backend/apps/media_library/models.py
+++ b/backend/apps/media_library/models.py
@@ -26,9 +26,16 @@ class MediaItem(BaseModel):
         db_comment="The media gallery this item belongs to.",
     )
 
+    class MediaItemType(models.TextChoices):
+        IMAGE = "image", "Image"
+        VIDEO = "video", "Video"
+        AUDIO = "audio", "Audio"
+
+
     type = models.CharField(
-        max_length=50,
-        db_comment="Type of media item (e.g., image, video).",
+        max_length=20,
+        choices=MediaItemType.choices,
+        db_comment="Type of media item."
     )
 
     format = models.CharField(

--- a/backend/apps/media_library/views.py
+++ b/backend/apps/media_library/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.

--- a/backend/apps/productions/models.py
+++ b/backend/apps/productions/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from apps.core.model import BaseModel
 from apps.languages.models import Language
 from apps.genres.models import Genre
+from apps.media_library.models import MediaGallery
 
 class UitDatabaseTheme(BaseModel):
     """Model representing a theme in the UIT database."""
@@ -67,7 +68,7 @@ class Production(BaseModel):
     )
 
     media_gallery = models.ForeignKey(
-        MediaGallery, # TODO: implement MediaGallery model
+        MediaGallery,
         null=True,
         blank=True,
         on_delete=models.SET_NULL,

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -47,6 +47,7 @@ LOCAL_APPS = [
     'apps.events',
     'apps.genres',
     'apps.locations',
+    'apps.media_library',
     # TODO add more local apps here
 ]
 

--- a/backend/tests/factories/media_library.py
+++ b/backend/tests/factories/media_library.py
@@ -23,7 +23,7 @@ class MediaItemFactory(factory.django.DjangoModelFactory):
         model = MediaItem
 
     gallery = factory.SubFactory(MediaGalleryFactory)
-    type = "image"
+    type = MediaItem.MediaItemType.IMAGE
     format = "jpg"
     original_filename = factory.LazyAttribute(lambda _: faker.file_name())
     position = factory.Sequence(lambda n: n)

--- a/backend/tests/factories/media_library.py
+++ b/backend/tests/factories/media_library.py
@@ -1,0 +1,50 @@
+import factory
+from faker import Faker
+from apps.media_library.models import (
+    MediaGallery,
+    MediaItem,
+    MediaItemTranslation,
+    MediaItemCrop,
+)
+from tests.factories.language import LanguageFactory
+
+faker = Faker()
+
+
+class MediaGalleryFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = MediaGallery
+
+    name = factory.Sequence(lambda n: f"Gallery_{n}")
+
+
+class MediaItemFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = MediaItem
+
+    gallery = factory.SubFactory(MediaGalleryFactory)
+    type = "image"
+    format = "jpg"
+    original_filename = factory.LazyAttribute(lambda _: faker.file_name())
+    position = factory.Sequence(lambda n: n)
+
+
+class MediaItemTranslationFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = MediaItemTranslation
+
+    media_item = factory.SubFactory(MediaItemFactory)
+    language = factory.SubFactory(LanguageFactory)
+    title = factory.LazyAttribute(lambda _: faker.word())
+    description = factory.LazyAttribute(lambda _: faker.sentence())
+    credits = factory.LazyAttribute(lambda _: faker.name())
+    link = factory.LazyAttribute(lambda _: faker.url())
+
+
+class MediaItemCropFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = MediaItemCrop
+
+    media_item = factory.SubFactory(MediaItemFactory)
+    name = factory.Sequence(lambda n: f"crop_{n}")
+    url = factory.LazyAttribute(lambda _: faker.url())

--- a/backend/tests/media_library/test_media_library.py
+++ b/backend/tests/media_library/test_media_library.py
@@ -84,11 +84,11 @@ class TestMediaItem:
         item.full_clean()  # should not raise
 
     def test_str_with_filename(self):
-        item = MediaItemFactory(type="image", original_filename="banner.jpg")
+        item = MediaItemFactory(type=MediaItem.MediaItemType.IMAGE, original_filename="banner.jpg")
         assert str(item) == "image - banner.jpg"
 
     def test_str_without_filename(self):
-        item = MediaItemFactory(type="video", original_filename="")
+        item = MediaItemFactory(type=MediaItem.MediaItemType.VIDEO, original_filename="")
         assert str(item) == "video - Unnamed"
 
     def test_delete_cascades_to_translations(self):
@@ -125,7 +125,7 @@ class TestMediaItemTranslation:
 
     def test_str_representation(self):
         language = LanguageFactory(code="en")
-        item = MediaItemFactory(type="image")
+        item = MediaItemFactory(type=MediaItem.MediaItemType.IMAGE)
         translation = MediaItemTranslationFactory(
             media_item=item,
             language=language,
@@ -134,7 +134,7 @@ class TestMediaItemTranslation:
 
         result = str(translation)
 
-        assert "image" in result
+        assert MediaItem.MediaItemType.IMAGE in result
         assert "en" in result
 
     def test_optional_fields_can_be_blank(self):
@@ -176,12 +176,12 @@ class TestMediaItemCrop:
             MediaItemCropFactory(media_item=item, name="thumbnail")
 
     def test_str_representation(self):
-        item = MediaItemFactory(type="image")
+        item = MediaItemFactory(type=MediaItem.MediaItemType.IMAGE)
         crop = MediaItemCropFactory(media_item=item, name="thumbnail")
 
         result = str(crop)
 
-        assert "image" in result
+        assert MediaItem.MediaItemType.IMAGE in result
         assert "thumbnail" in result
 
     def test_requires_name(self):

--- a/backend/tests/media_library/test_media_library.py
+++ b/backend/tests/media_library/test_media_library.py
@@ -1,0 +1,198 @@
+import pytest
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError
+
+from apps.media_library.models import (
+    MediaGallery,
+    MediaItem,
+    MediaItemTranslation,
+    MediaItemCrop,
+)
+
+from tests.factories.language import LanguageFactory
+from tests.factories.media_library import (
+    MediaGalleryFactory,
+    MediaItemFactory,
+    MediaItemTranslationFactory,
+    MediaItemCropFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+# =====================================================
+# MediaGallery
+# =====================================================
+
+class TestMediaGallery:
+
+    def test_requires_name(self):
+        gallery = MediaGalleryFactory.build(name="")
+        with pytest.raises(ValidationError):
+            gallery.full_clean()
+
+    def test_str_returns_name(self):
+        gallery = MediaGalleryFactory(name="Homepage Gallery")
+        assert str(gallery) == "Homepage Gallery"
+
+    def test_reverse_relation_media_items(self):
+        gallery = MediaGalleryFactory()
+        MediaItemFactory.create_batch(3, gallery=gallery)
+
+        assert gallery.media_items.count() == 3
+
+    def test_deleting_gallery_cascades_to_media_items(self):
+        gallery = MediaGalleryFactory()
+        MediaItemFactory.create_batch(2, gallery=gallery)
+
+        gallery.delete()
+
+        assert MediaItem.objects.count() == 0
+
+
+# =====================================================
+# MediaItem
+# =====================================================
+
+class TestMediaItem:
+
+    def test_requires_gallery(self):
+        item = MediaItemFactory.build(gallery=None)
+        with pytest.raises(ValidationError):
+            item.full_clean()
+
+    def test_position_defaults_to_zero(self):
+        item = MediaItemFactory()
+        assert item.position == 0
+
+    def test_ordering_by_position(self):
+        gallery = MediaGalleryFactory()
+        item3 = MediaItemFactory(gallery=gallery, position=3)
+        item1 = MediaItemFactory(gallery=gallery, position=1)
+        item2 = MediaItemFactory(gallery=gallery, position=2)
+
+        items = list(MediaItem.objects.filter(gallery=gallery))
+
+        assert items == [item1, item2, item3]
+
+    def test_blank_original_filename_allowed(self):
+        item = MediaItemFactory(original_filename="")
+        item.full_clean()  # should not raise
+
+    def test_width_height_optional(self):
+        item = MediaItemFactory(width=None, height=None)
+        item.full_clean()  # should not raise
+
+    def test_str_with_filename(self):
+        item = MediaItemFactory(type="image", original_filename="banner.jpg")
+        assert str(item) == "image - banner.jpg"
+
+    def test_str_without_filename(self):
+        item = MediaItemFactory(type="video", original_filename="")
+        assert str(item) == "video - Unnamed"
+
+    def test_delete_cascades_to_translations(self):
+        item = MediaItemFactory()
+        MediaItemTranslationFactory.create_batch(2, media_item=item)
+
+        item.delete()
+
+        assert MediaItemTranslation.objects.count() == 0
+
+    def test_delete_cascades_to_crops(self):
+        item = MediaItemFactory()
+        MediaItemCropFactory.create_batch(2, media_item=item)
+
+        item.delete()
+
+        assert MediaItemCrop.objects.count() == 0
+
+
+# =====================================================
+# MediaItemTranslation
+# =====================================================
+
+class TestMediaItemTranslation:
+
+    def test_unique_per_media_item_and_language(self):
+        language = LanguageFactory()
+        item = MediaItemFactory()
+
+        MediaItemTranslationFactory(media_item=item, language=language)
+
+        with pytest.raises(IntegrityError):
+            MediaItemTranslationFactory(media_item=item, language=language)
+
+    def test_str_representation(self):
+        language = LanguageFactory(code="en")
+        item = MediaItemFactory(type="image")
+        translation = MediaItemTranslationFactory(
+            media_item=item,
+            language=language,
+            title="Banner",
+        )
+
+        result = str(translation)
+
+        assert "image" in result
+        assert "en" in result
+
+    def test_optional_fields_can_be_blank(self):
+        translation = MediaItemTranslationFactory(
+            title="",
+            description="",
+            credits="",
+            link="",
+        )
+        translation.full_clean()  # should not raise
+
+    def test_language_reverse_relation(self):
+        language = LanguageFactory()
+        MediaItemTranslationFactory.create_batch(3, language=language)
+
+        assert language.media_item_translations.count() == 3
+
+    def test_deleting_language_cascades(self):
+        language = LanguageFactory()
+        MediaItemTranslationFactory(language=language)
+
+        language.delete()
+
+        assert MediaItemTranslation.objects.count() == 0
+
+
+# =====================================================
+# MediaItemCrop
+# =====================================================
+
+class TestMediaItemCrop:
+
+    def test_unique_per_media_item_and_name(self):
+        item = MediaItemFactory()
+
+        MediaItemCropFactory(media_item=item, name="thumbnail")
+
+        with pytest.raises(IntegrityError):
+            MediaItemCropFactory(media_item=item, name="thumbnail")
+
+    def test_str_representation(self):
+        item = MediaItemFactory(type="image")
+        crop = MediaItemCropFactory(media_item=item, name="thumbnail")
+
+        result = str(crop)
+
+        assert "image" in result
+        assert "thumbnail" in result
+
+    def test_requires_name(self):
+        crop = MediaItemCropFactory.build(name="")
+        with pytest.raises(ValidationError):
+            crop.full_clean()
+
+    def test_deleting_media_item_cascades_to_crops(self):
+        item = MediaItemFactory()
+        MediaItemCropFactory.create_batch(2, media_item=item)
+
+        item.delete()
+
+        assert MediaItemCrop.objects.count() == 0

--- a/backend/tests/media_library/test_media_library.py
+++ b/backend/tests/media_library/test_media_library.py
@@ -62,7 +62,8 @@ class TestMediaItem:
             item.full_clean()
 
     def test_position_defaults_to_zero(self):
-        item = MediaItemFactory()
+        gallery = MediaGalleryFactory()
+        item = MediaItem.objects.create(gallery=gallery, type="image")
         assert item.position == 0
 
     def test_ordering_by_position(self):


### PR DESCRIPTION
Introduced a new `media_library` app with the following models and tests:

- `MediaGallery`
- `MediaItem`
- `MediaItemTranslation`
- `MediaItemCrop`

Features:
- Proper relationships (ForeignKeys with related names)
- Unique constraints where needed
- Ordering and string representations
- App registered in `settings`

## Integration

- Connected `MediaGallery` to the `productions` app via a `ForeignKey`.
- Added `media_library` to `INSTALLED_APPS`.
