### PR TITLE
Use base language for display strings in admin and api

### DIFF
--- a/backend/apps/core/models.py
+++ b/backend/apps/core/models.py
@@ -8,6 +8,7 @@ a record is written to the database.
 """
 
 from django.db import models
+from django.conf import settings
 
 
 class BaseModel(models.Model):
@@ -75,3 +76,37 @@ class BaseModel(models.Model):
         """
         self.full_clean()
         super().save(*args, **kwargs)
+
+    @classmethod
+    def base_language_code(cls) -> str:
+        """
+        Returns the project's base language code.
+        """
+        code = getattr(settings, "LANGUAGE_CODE", "en")
+        return code.split("-")[0].lower()
+
+    def get_base_translation(self, related_name="translations"):
+        """
+        Returns the translation object for the base language,
+        falling back to the first available translation.
+        """
+        manager = getattr(self, related_name, None)
+        if not manager:
+            return None
+
+        base_code = self.base_language_code()
+        return (
+            manager.filter(language__code=base_code).first()
+            or manager.first()
+        )
+
+    def get_base_display_name(
+        self,
+        related_name="translations",
+        name_field="name",
+        fallback=None,
+    ):
+        tr = self.get_base_translation(related_name=related_name)
+        if not tr:
+            return fallback
+        return getattr(tr, name_field, fallback)

--- a/backend/apps/core/models.py
+++ b/backend/apps/core/models.py
@@ -95,10 +95,8 @@ class BaseModel(models.Model):
             return None
 
         base_code = self.base_language_code()
-        return (
-            manager.filter(language__code=base_code).first()
-            or manager.first()
-        )
+        qs = manager.all()
+        return qs.filter(language__code=base_code).first() or qs.first()
 
     def get_base_display_name(
         self,
@@ -109,4 +107,4 @@ class BaseModel(models.Model):
         tr = self.get_base_translation(related_name=related_name)
         if not tr:
             return fallback
-        return getattr(tr, name_field, fallback)
+        return getattr(tr, name_field, None) or fallback

--- a/backend/apps/core/serializers.py
+++ b/backend/apps/core/serializers.py
@@ -209,18 +209,19 @@ class TranslatableSerializerMixin:
         translations = getattr(obj, related_name).all()
         base_code = self.get_base_language_code()
 
-        # Prefer base language
-        for t in translations:
-            if t.language.code == base_code:
-                value = getattr(t, field_name, None)
-                if value:
-                    return value
+        first_available = None
 
-        # Fallback: first non-empty value
         for t in translations:
             value = getattr(t, field_name, None)
-            if value:
+            if not value:
+                continue
+            
+            # If this translation matches the base language, return it immediately
+            if t.language.code == base_code:
                 return value
+            
+            # Otherwise, keep track of the first available translation as a fallback
+            if first_available is None:
+                first_available = value
 
-        # Final fallback
-        return fallback
+        return first_available or fallback

--- a/backend/apps/core/serializers.py
+++ b/backend/apps/core/serializers.py
@@ -29,6 +29,7 @@ be query-free, viewsets must include the relevant ``Prefetch`` in their
 queryset. See the individual app viewsets for examples.
 """
 
+from django.conf import settings
 
 class TranslatableSerializerMixin:
     """
@@ -105,3 +106,121 @@ class TranslatableSerializerMixin:
             for t in translations
             if getattr(t, field_name)
         }
+    
+    def get_base_language_code(self) -> str:
+        """
+        Return the project's primary language code.
+
+        The base language is derived from ``settings.LANGUAGE_CODE``.
+        If the setting includes a regional variant (e.g. ``"en-us"``),
+        only the primary ISO 639-1 language subtag (``"en"``) is used.
+
+        This ensures consistent behaviour across:
+
+        - Base-language display fields in API responses
+        - Admin dropdown labels
+        - Any serializer that needs a single canonical language value
+
+        Returns
+        -------
+        str
+            The primary language code (e.g. ``"en"``, ``"nl"``, ``"fr"``).
+
+        Examples
+        --------
+        >>> settings.LANGUAGE_CODE = "en-us"
+        >>> self.get_base_language_code()
+        "en"
+
+        >>> settings.LANGUAGE_CODE = "nl"
+        >>> self.get_base_language_code()
+        "nl"
+        """
+        return (getattr(settings, "LANGUAGE_CODE", "en") or "en").split("-")[0].lower()
+
+    def get_base_translated_value(
+        self,
+        obj,
+        field_name: str,
+        related_name: str = "translations",
+        fallback=None,
+    ):
+        """
+        Return a single translated value in the project's base language.
+
+        This method is designed for API "display fields" (e.g. ``display_name``)
+        where a single human-readable label is required rather than a full
+        ``{language_code: value}`` mapping.
+
+        Resolution strategy
+        -------------------
+        1. Prefer the translation whose ``language.code`` matches the
+           project's base language (see :meth:`get_base_language_code`).
+        2. If no base-language translation exists, fall back to the first
+           non-empty translation value available.
+        3. If no translations contain a truthy value for ``field_name``,
+           return ``fallback``.
+
+        Performance considerations
+        --------------------------
+        This method reads from ``obj.<related_name>.all()`` and therefore
+        assumes the relation has been prefetched in the queryset. When used
+        correctly alongside ``prefetch_related``, no additional database
+        queries are triggered.
+
+        Parameters
+        ----------
+        obj:
+            The model instance being serialised. Must expose a reverse
+            relation named ``related_name`` whose rows contain:
+
+            - a ``language`` FK with a ``code`` attribute
+            - a field named ``field_name``
+
+        field_name:
+            The translated field to extract (e.g. ``"title"``,
+            ``"description"``, ``"name"``).
+
+        related_name:
+            The reverse relation name that contains translation rows.
+            Defaults to ``"translations"``, which matches the convention
+            used across the project.
+
+        fallback:
+            Value returned when no suitable translation is found.
+            Typically ``None`` or a technical identifier (e.g. ``obj.id``).
+
+        Returns
+        -------
+        Any
+            The translated value in the base language, or a fallback.
+
+        Examples
+        --------
+        >>> self.get_base_translated_value(production, "title")
+        "The Last Evening"
+
+        >>> self.get_base_translated_value(price_rank, "description")
+        "Student"
+
+        >>> self.get_base_translated_value(obj, "title", fallback="Untitled")
+        "Untitled"
+        """
+        translations = getattr(obj, related_name).all()
+        base_code = self.get_base_language_code()
+
+        # Prefer base language
+        for t in translations:
+            if t.language.code == base_code:
+                value = getattr(t, field_name, None)
+                if value:
+                    return value
+
+        # Fallback: first non-empty value
+        for t in translations:
+            value = getattr(t, field_name, None)
+            if value:
+                return value
+
+        # Final fallback
+        return fallback

--- a/backend/apps/events/models.py
+++ b/backend/apps/events/models.py
@@ -116,7 +116,9 @@ class Event(BaseModel):
             raise ValidationError("Event end time must be after start time.")
 
     def __str__(self) -> str:
-        return f"Event {self.id} - {self.production} @ {self.starts_at}"
+        production = str(self.production)
+        date = self.starts_at.strftime("%Y-%m-%d %H:%M") if self.starts_at else "TBA"
+        return f"{production} @ {date}"
 
 
 # ===========================================================================
@@ -190,4 +192,5 @@ class EventPrice(BaseModel):
         ]
 
     def __str__(self) -> str:
-        return f"EventPrice {self.id} - Event {self.event_id} / Rank {self.price_rank_id}"
+        rank = str(self.price_rank) if self.price_rank else "No rank"
+        return f"{self.event} - {rank} (€{self.amount})"

--- a/backend/apps/events/models.py
+++ b/backend/apps/events/models.py
@@ -116,7 +116,7 @@ class Event(BaseModel):
             raise ValidationError("Event end time must be after start time.")
 
     def __str__(self) -> str:
-        production = str(self.production)
+        production = str(self.production) if self.production else "Unknown Production"
         date = self.starts_at.strftime("%Y-%m-%d %H:%M") if self.starts_at else "TBA"
         return f"{production} @ {date}"
 

--- a/backend/apps/events/serializers.py
+++ b/backend/apps/events/serializers.py
@@ -11,11 +11,11 @@ through-table. It is nested read-only inside ``EventSerializer`` via the
 """
 
 from rest_framework import serializers
-
+from apps.core.serializers import TranslatableSerializerMixin
 from .models import Event, EventPrice
 
 
-class EventPriceSerializer(serializers.ModelSerializer):
+class EventPriceSerializer(TranslatableSerializerMixin, serializers.ModelSerializer):
     """
     Represents a single price tier assigned to an event.
 
@@ -26,6 +26,18 @@ class EventPriceSerializer(serializers.ModelSerializer):
     inside ``EventSerializer``. Use the dedicated **Event Price** endpoints
     to create or modify price entries.
     """
+    price_rank_display = serializers.SerializerMethodField()
+
+    def get_price_rank_display(self, obj):
+        """Return the price rank name in the project's base language."""
+        if not obj.price_rank:
+            return None
+        return self.get_base_translated_value(
+            obj.price_rank,
+            field_name="description",
+            related_name="translations",
+            fallback=str(obj.price_rank_id),
+        )
 
     class Meta:
         model = EventPrice
@@ -33,6 +45,7 @@ class EventPriceSerializer(serializers.ModelSerializer):
             "id",
             "event",
             "price_rank",
+            "price_rank_display",
             "amount",
             "available",
         ]
@@ -47,6 +60,9 @@ class EventPriceSerializer(serializers.ModelSerializer):
                     "`null` when the rank has been deleted."
                 ),
             },
+            "price_rank_display": {
+                "help_text": "String for the price rank in the display representation."
+            },
             "amount": {
                 "help_text": "Ticket price in euro (e.g. `18.00`).",
             },
@@ -56,7 +72,7 @@ class EventPriceSerializer(serializers.ModelSerializer):
         }
 
 
-class EventSerializer(serializers.ModelSerializer):
+class EventSerializer(TranslatableSerializerMixin, serializers.ModelSerializer):
     """
     Full representation of an Event.
 
@@ -86,12 +102,37 @@ class EventSerializer(serializers.ModelSerializer):
         ),
     )
 
+    production_display = serializers.SerializerMethodField()
+    hall_display = serializers.SerializerMethodField()
+
+    def get_production_display(self, obj):
+        """Return the production name in the project's base language."""
+        return self.get_base_translated_value(
+            obj.production,
+            field_name="title",
+            related_name="translations",
+            fallback=str(obj.production_id),
+        )
+
+    def get_hall_display(self, obj):
+        """Return the hall name in the project's base language."""
+        if not obj.hall:
+            return None
+        return self.get_base_translated_value(
+            obj.hall,
+            field_name="name",
+            related_name="translations",
+            fallback=str(obj.hall_id),
+        )
+
     class Meta:
         model = Event
         fields = [
             "id",
             "production",
+            "production_display",
             "hall",
+            "hall_display",
             "starts_at",
             "ends_at",
             "ticketing_url",
@@ -102,11 +143,17 @@ class EventSerializer(serializers.ModelSerializer):
             "production": {
                 "help_text": "PK of the production this event is a performance of.",
             },
+            "production_display": {
+                "help_text": "String for the production in the display representation."
+            },
             "hall": {
                 "help_text": (
                     "PK of the hall in which the event takes place. "
                     "`null` for online or location-independent events."
                 ),
+            },
+            "hall_display": {
+                "help_text": "String for the hall in the display representation."
             },
             "starts_at": {
                 "help_text": "ISO 8601 UTC datetime at which the event begins.",

--- a/backend/apps/genres/admin.py
+++ b/backend/apps/genres/admin.py
@@ -28,10 +28,14 @@ class GenreAdmin(BaseAdmin):
 
     list_display = ("id", "type", "use_as")
     list_filter = ("use_as",)
-    search_fields = ("type",)
+    search_fields = ("type", "translations__name",)
     ordering = ("id",)
     autocomplete_fields = ("use_as",)
     inlines = [GenreTranslationInline]
+
+    def get_queryset(self, request):
+        """Prefetch translations to avoid N+1 queries on the detail page."""
+        return super().get_queryset(request).prefetch_related("translations")
 
 
 @admin.register(GenreTranslation)

--- a/backend/apps/genres/models.py
+++ b/backend/apps/genres/models.py
@@ -75,7 +75,11 @@ class Genre(BaseModel):
         ordering = ["id"]
 
     def __str__(self) -> str:
-        return self.type
+        name = self.get_base_display_name(
+            related_name="translations",
+            fallback=None,
+        )
+        return f"{name} ({self.type})" if name else self.type
 
 
 class GenreTranslation(BaseModel):

--- a/backend/apps/genres/serializers.py
+++ b/backend/apps/genres/serializers.py
@@ -31,7 +31,7 @@ class GenreUseAsSerializer(serializers.ModelSerializer):
         }
 
 
-class GenreSerializer(serializers.ModelSerializer, TranslatableSerializerMixin):
+class GenreSerializer(TranslatableSerializerMixin, serializers.ModelSerializer):
     """
     Represents a Genre.
 
@@ -47,10 +47,18 @@ class GenreSerializer(serializers.ModelSerializer, TranslatableSerializerMixin):
         ),
     )
 
+    display_name = serializers.SerializerMethodField(
+        help_text=(
+            "Human-readable name in the project's base language "
+            "(e.g. `Theatre`). Falls back to the first available "
+            "translation when the base language is missing."
+        )
+    )
+
     class Meta:
         model = Genre
-        fields = ["id", "type", "use_as", "name"]
-        read_only_fields = ["id", "name"]
+        fields = ["id", "type", "use_as", "name", "display_name"]
+        read_only_fields = ["id", "name", "display_name"]
         extra_kwargs = {
             "type": {
                 "help_text": (
@@ -69,3 +77,7 @@ class GenreSerializer(serializers.ModelSerializer, TranslatableSerializerMixin):
     def get_name(self, obj: Genre) -> dict[str, str] | None:
         """Return all available translations as a language-code dictionary."""
         return self.get_translated_field(obj, "name")
+    
+    def get_display_name(self, obj: Genre) -> str | None:
+        """Return the genre name in the project's base language."""
+        return self.get_base_translated_value(obj, "name")

--- a/backend/apps/locations/admin.py
+++ b/backend/apps/locations/admin.py
@@ -26,9 +26,18 @@ class LocationAdmin(BaseAdmin):
 
     list_display = ("id", "city", "street", "number", "country", "is_own_location")
     list_filter = ("is_own_location",)
-    search_fields = ("city", "street", "country")
+    search_fields = (
+        "translations__name",
+        "city",
+        "street",
+        "country",
+    )
     ordering = ("id",)
     inlines = [LocationTranslationInline]
+
+    def get_queryset(self, request):
+        "Avoiding N+1 queries by prefetching related translations."
+        return super().get_queryset(request).prefetch_related("translations")
 
 
 @admin.register(LocationTranslation)
@@ -55,10 +64,18 @@ class SpaceAdmin(BaseAdmin):
 
     list_display = ("id", "location")
     list_select_related = ("location",)
-    search_fields = ("location__city", "location__street")
+    search_fields = (
+        "translations__name",
+        "location__city",
+        "location__street"
+    )
     ordering = ("id",)
     autocomplete_fields = ("location",)
     inlines = [SpaceTranslationInline]
+
+    def get_queryset(self, request):
+        "Avoiding N+1 queries by prefetching related translations."
+        return super().get_queryset(request).prefetch_related("translations")
 
 
 @admin.register(SpaceTranslation)
@@ -87,11 +104,15 @@ class HallAdmin(BaseAdmin):
     list_display_links = ("id", "space")
     list_filter = ("seat_selection", "open_seating")
     list_select_related = ("space", "space__location")
-    search_fields = ("space__location__city", "space__location__street")
+    search_fields = ("translations__name", "space__location__city", "space__location__street")
     ordering = ("id",)
     autocomplete_fields = ("space",)
     inlines = [HallTranslationInline]
 
+    def get_queryset(self, request):
+        "Avoiding N+1 queries by prefetching related translations."
+        return super().get_queryset(request).prefetch_related("translations")
+    
 
 @admin.register(HallTranslation)
 class HallTranslationAdmin(BaseAdmin):

--- a/backend/apps/locations/models.py
+++ b/backend/apps/locations/models.py
@@ -93,6 +93,9 @@ class Location(BaseModel):
         ordering = ["id"]
 
     def __str__(self) -> str:
+        name = self.get_base_display_name(related_name="translations", fallback=None)
+        if name:
+            return name
         return f"{self.city} - {self.street} {self.number}"
 
 
@@ -174,7 +177,10 @@ class Space(BaseModel):
         ordering = ["id"]
 
     def __str__(self) -> str:
-        return f"Space {self.id} - {self.location}"
+        name = self.get_base_display_name(related_name="translations", fallback=None)
+        if name:
+            return f"{name} @ {self.location}"
+        return f"Space {self.id} @ {self.location}"
 
 
 class SpaceTranslation(BaseModel):
@@ -269,6 +275,9 @@ class Hall(BaseModel):
         ordering = ["id"]
 
     def __str__(self) -> str:
+        name = self.get_base_display_name(related_name="translations", fallback=None)
+        if name:
+            return f"{name} @ {self.space}"
         return f"Hall {self.id} @ {self.space}"
 
 

--- a/backend/apps/locations/serializers.py
+++ b/backend/apps/locations/serializers.py
@@ -31,6 +31,14 @@ class LocationSerializer(serializers.ModelSerializer, TranslatableSerializerMixi
         ),
     )
 
+    display_name = serializers.SerializerMethodField(
+        help_text=(
+            "Human-readable location name in the project's base language. "
+            "Falls back to the first available translation when the base "
+            "language translation is missing."
+        )
+    )
+
     class Meta:
         model = Location
         fields = [
@@ -44,8 +52,9 @@ class LocationSerializer(serializers.ModelSerializer, TranslatableSerializerMixi
             "phone_2",
             "is_own_location",
             "name",
+            "display_name"
         ]
-        read_only_fields = ["id", "name"]
+        read_only_fields = ["id", "display_name", "name"]
         extra_kwargs = {
             "street": {"help_text": "Street name of the location."},
             "number": {"help_text": "Street / house number."},
@@ -62,6 +71,10 @@ class LocationSerializer(serializers.ModelSerializer, TranslatableSerializerMixi
     def get_name(self, obj: Location) -> dict[str, str] | None:
         """Return all available translations as a language-code dictionary."""
         return self.get_translated_field(obj, "name")
+    
+    def get_display_name(self, obj: Location) -> str | None:
+        """Return the location name in the project's base language."""
+        return self.get_base_translated_value(obj, "name")
 
 
 class SpaceSerializer(serializers.ModelSerializer, TranslatableSerializerMixin):
@@ -80,14 +93,19 @@ class SpaceSerializer(serializers.ModelSerializer, TranslatableSerializerMixin):
         ),
     )
 
+    display_name = serializers.SerializerMethodField(
+        help_text="Human-readable space name in the project's base language."
+    )
+
     class Meta:
         model = Space
         fields = [
             "id",
             "location",
             "name",
+            "display_name"
         ]
-        read_only_fields = ["id", "name"]
+        read_only_fields = ["id", "name", "display_name"]
         extra_kwargs = {
             "location": {
                 "help_text": "Primary key of the parent **Location** this space belongs to.",
@@ -97,6 +115,10 @@ class SpaceSerializer(serializers.ModelSerializer, TranslatableSerializerMixin):
     def get_name(self, obj: Space) -> dict[str, str] | None:
         """Return all available translations as a language-code dictionary."""
         return self.get_translated_field(obj, "name")
+    
+    def get_display_name(self, obj: Space) -> str | None:
+        """Return the space name in the project's base language."""
+        return self.get_base_translated_value(obj, "name")
 
 
 class HallSerializer(serializers.ModelSerializer, TranslatableSerializerMixin):
@@ -113,6 +135,10 @@ class HallSerializer(serializers.ModelSerializer, TranslatableSerializerMixin):
             "(e.g. {\"en\": \"Main Hall\", \"fr\": \"Grande Salle\"}). "
             "Read-only — use the translation endpoints to manage translations."
         ),
+    )
+
+    display_name = serializers.SerializerMethodField(
+        help_text="Human-readable hall name in the project's base language."
     )
 
     remark = serializers.SerializerMethodField(
@@ -133,9 +159,10 @@ class HallSerializer(serializers.ModelSerializer, TranslatableSerializerMixin):
             "seat_selection",
             "open_seating",
             "name",
+            "display_remark",
             "remark",
         ]
-        read_only_fields = ["id", "name", "remark"]
+        read_only_fields = ["id", "name", "display_remark", "remark"]
         extra_kwargs = {
             "space": {
                 "help_text": "Primary key of the parent **Space** this hall belongs to.",
@@ -151,6 +178,10 @@ class HallSerializer(serializers.ModelSerializer, TranslatableSerializerMixin):
     def get_name(self, obj: Hall) -> dict[str, str] | None:
         """Return all available translations as a language-code dictionary."""
         return self.get_translated_field(obj, "name")
+    
+    def get_display_name(self, obj: Hall) -> str | None:
+        """Return the hall name in the project's base language."""
+        return self.get_base_translated_value(obj, "name")
 
     def get_remark(self, obj: Hall) -> dict[str, str] | None:
         """Return all available translations as a language-code dictionary."""

--- a/backend/apps/locations/serializers.py
+++ b/backend/apps/locations/serializers.py
@@ -159,7 +159,7 @@ class HallSerializer(serializers.ModelSerializer, TranslatableSerializerMixin):
             "seat_selection",
             "open_seating",
             "name",
-            "display_remark",
+            "display_name",
             "remark",
         ]
         read_only_fields = ["id", "name", "display_remark", "remark"]

--- a/backend/apps/media_library/serializers.py
+++ b/backend/apps/media_library/serializers.py
@@ -41,7 +41,7 @@ class MediaItemCropSerializer(serializers.ModelSerializer):
         }
 
 
-class MediaItemSerializer(serializers.ModelSerializer, TranslatableSerializerMixin):
+class MediaItemSerializer(TranslatableSerializerMixin, serializers.ModelSerializer):
     """
     Represents a MediaItem with its translated metadata and nested crops.
 
@@ -59,6 +59,13 @@ class MediaItemSerializer(serializers.ModelSerializer, TranslatableSerializerMix
             "(e.g. {\"en\": \"Poster\", \"fr\": \"Affiche\"}). "
             "Read-only — use the translation endpoints to manage translations."
         ),
+    )
+
+    display_title = serializers.SerializerMethodField(
+        help_text=(
+            "Title in the project's base language (derived from settings.LANGUAGE_CODE). "
+            "Falls back to the first available translation when missing."
+        )
     )
 
     description = serializers.SerializerMethodField(
@@ -100,12 +107,13 @@ class MediaItemSerializer(serializers.ModelSerializer, TranslatableSerializerMix
             "width",
             "height",
             "title",
+            "display_title",
             "description",
             "credits",
             "link",
             "crops",
         ]
-        read_only_fields = ["id", "title", "description", "credits", "link", "crops"]
+        read_only_fields = ["id", "display_title", "title", "description", "credits", "link", "crops"]
         extra_kwargs = {
             "gallery": {
                 "help_text": "Primary key of the parent **MediaGallery** this item belongs to.",
@@ -133,6 +141,10 @@ class MediaItemSerializer(serializers.ModelSerializer, TranslatableSerializerMix
     def get_title(self, obj: MediaItem) -> dict[str, str] | None:
         """Return all available translations as a language-code dictionary."""
         return self.get_translated_field(obj, "title")
+    
+    def get_display_title(self, obj: MediaItem) -> str | None:
+        """Return the media item title in the project's base language."""
+        return self.get_base_translated_value(obj, "title")
 
     def get_description(self, obj: MediaItem) -> dict[str, str] | None:
         """Return all available translations as a language-code dictionary."""

--- a/backend/apps/pricing/serializers.py
+++ b/backend/apps/pricing/serializers.py
@@ -32,6 +32,13 @@ class PriceSerializer(serializers.ModelSerializer, TranslatableSerializerMixin):
         ),
     )
 
+    display_description = serializers.SerializerMethodField(
+        help_text=(
+            "Human-readable label in the project's base language. "
+            "Falls back to the first available translation when missing."
+        )
+    )
+
     class Meta:
         model = Price
         fields = [
@@ -45,8 +52,9 @@ class PriceSerializer(serializers.ModelSerializer, TranslatableSerializerMixin):
             "sort_order",
             "cineville_box",
             "description",
+            "display_description"
         ]
-        read_only_fields = ["id", "description"]
+        read_only_fields = ["id", "description", "display_description"]
         extra_kwargs = {
             "type": {
                 "help_text": "Internal identifier for the price category (e.g. `full`, `student`).",
@@ -86,6 +94,10 @@ class PriceSerializer(serializers.ModelSerializer, TranslatableSerializerMixin):
     def get_description(self, obj: Price) -> dict[str, str] | None:
         """Return all available translations as a language-code dictionary."""
         return self.get_translated_field(obj, "description")
+    
+    def get_display_description(self, obj: Price) -> str | None:
+        """Return the price label in the project's base language."""
+        return self.get_base_translated_value(obj, field_name="description")
 
 
 class PriceRankSerializer(serializers.ModelSerializer, TranslatableSerializerMixin):
@@ -104,6 +116,13 @@ class PriceRankSerializer(serializers.ModelSerializer, TranslatableSerializerMix
         ),
     )
 
+    display_description = serializers.SerializerMethodField(
+        help_text=(
+            "Human-readable label in the project's base language. "
+            "Falls back to the first available translation when missing."
+        )
+    )
+
     class Meta:
         model = PriceRank
         fields = [
@@ -111,8 +130,9 @@ class PriceRankSerializer(serializers.ModelSerializer, TranslatableSerializerMix
             "position",
             "sold_out_buffer",
             "description",
+            "display_description"
         ]
-        read_only_fields = ["id", "description"]
+        read_only_fields = ["id", "description", "display_description"]
         extra_kwargs = {
             "position": {
                 "help_text": "Rank position used for ordering and priority. Must be unique.",
@@ -128,3 +148,6 @@ class PriceRankSerializer(serializers.ModelSerializer, TranslatableSerializerMix
     def get_description(self, obj: PriceRank) -> dict[str, str] | None:
         """Return all available translations as a language-code dictionary."""
         return self.get_translated_field(obj, "description")
+    
+    def get_display_description(self, obj: PriceRank) -> str | None:
+        return self.get_base_translated_value(obj, field_name="description")

--- a/backend/apps/productions/admin.py
+++ b/backend/apps/productions/admin.py
@@ -264,7 +264,7 @@ class ProductionGenreAdmin(BaseAdmin):
 
     search_fields = (
         "production__id",
-        "genre__type",
+        "genre__translations__name",
     )
 
     autocomplete_fields = ("production", "genre")
@@ -305,7 +305,7 @@ class ProductionTagAdmin(BaseAdmin):
 
     search_fields = (
         "production__id",
-        "tag__type",
+        "tag__translations__name",
     )
 
     autocomplete_fields = ("production", "tag")

--- a/backend/apps/productions/models.py
+++ b/backend/apps/productions/models.py
@@ -187,7 +187,12 @@ class Production(BaseModel):
         ordering = ["-id"]
 
     def __str__(self) -> str:
-        return f"Production {self.id}"
+        title = self.get_base_display_name(
+            related_name="translations",
+            name_field="title",
+            fallback=None,
+        )
+        return title or f"Production {self.id}"
 
 
 class ProductionTranslation(BaseModel):
@@ -374,7 +379,7 @@ class ProductionTag(BaseModel):
         ]
 
     def __str__(self) -> str:
-        return f"Tag {self.tag.type} for Production {self.production.id}"
+        return f"Tag {self.tag} for {self.production}"
 
 
 class ProductionGenre(BaseModel):
@@ -425,4 +430,4 @@ class ProductionGenre(BaseModel):
         ]
 
     def __str__(self) -> str:
-        return f"{self.genre.type}"
+        return str(self.genre)

--- a/backend/apps/productions/serializers.py
+++ b/backend/apps/productions/serializers.py
@@ -118,6 +118,20 @@ class ProductionSerializer(TranslatableSerializerMixin, serializers.ModelSeriali
         ),
     )
 
+    display_title = serializers.SerializerMethodField(
+        help_text=(
+            "Production title in the project's base language (derived from settings.LANGUAGE_CODE). "
+            "Falls back to the first available translation when missing."
+        ),
+    )
+
+    display_artist_name = serializers.SerializerMethodField(
+        help_text=(
+            "Artist or company name in the project's base language (derived from settings.LANGUAGE_CODE). "
+            "Falls back to the first available translation when missing."
+        ),
+    )
+
     # ---------------------------------------------------------------------------
     # Nested relations (read-only)
     # ---------------------------------------------------------------------------
@@ -153,6 +167,8 @@ class ProductionSerializer(TranslatableSerializerMixin, serializers.ModelSeriali
             "performer_type",
             "uit_database_theme",
             "uit_database_type",
+            "display_title",
+            "display_artist_name",
             "title",
             "artist_name",
             "tagline",
@@ -165,6 +181,8 @@ class ProductionSerializer(TranslatableSerializerMixin, serializers.ModelSeriali
             "id",
             "uit_database_theme",
             "uit_database_type",
+            "display_title",
+            "display_artist_name",
             "title",
             "artist_name",
             "tagline",
@@ -229,3 +247,11 @@ class ProductionSerializer(TranslatableSerializerMixin, serializers.ModelSeriali
     def get_description(self, obj: Production) -> str:
         """Return all available translations as a language-code dictionary."""
         return self.get_translated_field(obj, "description")
+    
+    def get_display_title(self, obj: Production) -> str | None:
+        """Return the base-language title (with fallback)."""
+        return self.get_base_translated_value(obj, field_name="title")
+
+    def get_display_artist_name(self, obj: Production) -> str | None:
+        """Return the base-language artist/company name (with fallback)."""
+        return self.get_base_translated_value(obj, field_name="artist_name")

--- a/backend/apps/tags/admin.py
+++ b/backend/apps/tags/admin.py
@@ -75,6 +75,7 @@ class TagAdmin(BaseAdmin):
     search_fields = (
         "type",
         "source",
+        "translations__name",
     )
 
     ordering = ("type", "id")

--- a/backend/apps/tags/models.py
+++ b/backend/apps/tags/models.py
@@ -154,4 +154,7 @@ class TagTranslation(BaseModel):
         ]
 
     def __str__(self) -> str:
-        return f"{self.language.code} - {self.name}"
+        name = self.get_base_display_name(related_name="translations", fallback=None)
+        if name:
+            return f"{name} ({self.type})" if self.type else name
+        return f"Tag ({self.type})" if self.type else f"Tag {self.id}"

--- a/backend/apps/tags/models.py
+++ b/backend/apps/tags/models.py
@@ -83,7 +83,12 @@ class Tag(BaseModel):
         ordering = ["id"]
 
     def __str__(self) -> str:
-        return f"Tag of type ({self.type})"
+        name = self.get_base_display_name(
+            related_name="translations",
+            name_field="name",
+            fallback=None,
+        )
+        return name or f"Tag {self.id}"
 
 
 class TagTranslation(BaseModel):

--- a/backend/apps/tags/models.py
+++ b/backend/apps/tags/models.py
@@ -154,7 +154,4 @@ class TagTranslation(BaseModel):
         ]
 
     def __str__(self) -> str:
-        name = self.get_base_display_name(related_name="translations", fallback=None)
-        if name:
-            return f"{name} ({self.type})" if self.type else name
-        return f"Tag ({self.type})" if self.type else f"Tag {self.id}"
+        return f"{self.language.code} - {self.name}"

--- a/backend/apps/tags/serializers.py
+++ b/backend/apps/tags/serializers.py
@@ -95,7 +95,7 @@ class TagSerializer(TranslatableSerializerMixin, serializers.ModelSerializer):
             "short_description",
             "url_title",
         ]
-        read_only_fields = ["id", "name", "short_description", "url_title"]
+        read_only_fields = ["id", "name", "short_description", "display_name", "display_short_description", "display_url_title", "url_title"]
         extra_kwargs = {
             "url": {
                 "help_text": "Public URL of the tag in the originating system. Empty string when not applicable.",

--- a/backend/apps/tags/serializers.py
+++ b/backend/apps/tags/serializers.py
@@ -57,6 +57,27 @@ class TagSerializer(TranslatableSerializerMixin, serializers.ModelSerializer):
         ),
     )
 
+    display_name = serializers.SerializerMethodField(
+        help_text=(
+            "Tag name in the project's base language (derived from settings.LANGUAGE_CODE). "
+            "Falls back to the first available translation when missing."
+        ),
+    )
+
+    display_short_description = serializers.SerializerMethodField(
+        help_text=(
+            "Short description in the project's base language (derived from settings.LANGUAGE_CODE). "
+            "Falls back to the first available translation when missing."
+        ),
+    )
+
+    display_url_title = serializers.SerializerMethodField(
+        help_text=(
+            "URL-safe title in the project's base language (derived from settings.LANGUAGE_CODE). "
+            "Falls back to the first available translation when missing."
+        ),
+    )
+
     class Meta:
         model = Tag
         fields = [
@@ -67,6 +88,9 @@ class TagSerializer(TranslatableSerializerMixin, serializers.ModelSerializer):
             "type",
             "is_external",
             "is_enabled",
+            "display_name",
+            "display_short_description",
+            "display_url_title",
             "name",
             "short_description",
             "url_title",
@@ -108,3 +132,15 @@ class TagSerializer(TranslatableSerializerMixin, serializers.ModelSerializer):
     def get_url_title(self, obj: Tag) -> str:
         """Return all available translations as a language-code dictionary."""
         return self.get_translated_field(obj, "url_title")
+    
+    def get_display_name(self, obj: Tag) -> str | None:
+        """Return the base-language tag name (with fallback)."""
+        return self.get_base_translated_value(obj, field_name="name")
+
+    def get_display_short_description(self, obj: Tag) -> str | None:
+        """Return the base-language short description (with fallback)."""
+        return self.get_base_translated_value(obj, field_name="short_description")
+
+    def get_display_url_title(self, obj: Tag) -> str | None:
+        """Return the base-language URL title (with fallback)."""
+        return self.get_base_translated_value(obj, field_name="url_title")

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -92,22 +92,17 @@ WSGI_APPLICATION = 'config.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/6.0/ref/settings/#databases
 
-# DATABASES = {
-#     "default": {
-#         "ENGINE": "django.db.backends.postgresql",
-#         "NAME": os.environ.get("DB_NAME", "viernulvier_archief"),
-#         "USER": os.environ.get("DB_USER", "postgres"),
-#         "PASSWORD": os.environ.get("DB_PASSWORD", ""),
-#         "HOST": os.environ.get("DB_HOST", "localhost"),
-#         "PORT": os.environ.get("DB_PORT", "5432"),
-#     }
-# }
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    }
-}
+     "default": {
+         "ENGINE": "django.db.backends.postgresql",
+         "NAME": os.environ.get("DB_NAME", "viernulvier_archief"),
+         "USER": os.environ.get("DB_USER", "postgres"),
+         "PASSWORD": os.environ.get("DB_PASSWORD", ""),
+         "HOST": os.environ.get("DB_HOST", "localhost"),
+         "PORT": os.environ.get("DB_PORT", "5432"),
+     }
+ }
+
 
 # Password validation
 # https://docs.djangoproject.com/en/6.0/ref/settings/#auth-password-validators

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -92,16 +92,27 @@ WSGI_APPLICATION = 'config.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/6.0/ref/settings/#databases
 
+#DATABASES = {
+#     "default": {
+#         "ENGINE": "django.db.backends.postgresql",
+#         "NAME": os.environ.get("DB_NAME", "viernulvier_archief"),
+#         "USER": os.environ.get("DB_USER", "postgres"),
+#         "PASSWORD": os.environ.get("DB_PASSWORD", ""),
+#         "HOST": os.environ.get("DB_HOST", "localhost"),
+#         "PORT": os.environ.get("DB_PORT", "5432"),
+#     }
+# }
+
 DATABASES = {
-     "default": {
-         "ENGINE": "django.db.backends.postgresql",
-         "NAME": os.environ.get("DB_NAME", "viernulvier_archief"),
-         "USER": os.environ.get("DB_USER", "postgres"),
-         "PASSWORD": os.environ.get("DB_PASSWORD", ""),
-         "HOST": os.environ.get("DB_HOST", "localhost"),
-         "PORT": os.environ.get("DB_PORT", "5432"),
-     }
- }
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.environ.get("DB_NAME", "viernulvier_archief"),
+        "USER": os.environ.get("DB_USER", "postgres"),
+        "PASSWORD": os.environ.get("DB_PASSWORD", ""),
+        "HOST": os.environ.get("DB_HOST", "localhost"),
+        "PORT": os.environ.get("DB_PORT", "5432"),
+    }
+}
 
 
 # Password validation

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -92,17 +92,6 @@ WSGI_APPLICATION = 'config.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/6.0/ref/settings/#databases
 
-#DATABASES = {
-#     "default": {
-#         "ENGINE": "django.db.backends.postgresql",
-#         "NAME": os.environ.get("DB_NAME", "viernulvier_archief"),
-#         "USER": os.environ.get("DB_USER", "postgres"),
-#         "PASSWORD": os.environ.get("DB_PASSWORD", ""),
-#         "HOST": os.environ.get("DB_HOST", "localhost"),
-#         "PORT": os.environ.get("DB_PORT", "5432"),
-#     }
-# }
-
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -104,7 +104,7 @@ DATABASES = {
 }
 
 
-# Password validation
+# Password validation 
 # https://docs.djangoproject.com/en/6.0/ref/settings/#auth-password-validators
 
 AUTH_PASSWORD_VALIDATORS = [

--- a/backend/tests/events/test_event_serializers.py
+++ b/backend/tests/events/test_event_serializers.py
@@ -66,7 +66,17 @@ class TestEventSerializerFields(TestCase):
         serializer = EventSerializer(self.event, context={"request": _drf_request(self.factory, "/dummy")})
         data = serializer.data
 
-        expected = {"id", "production", "hall", "starts_at", "ends_at", "ticketing_url", "prices"}
+        expected = {
+            "id",
+            "production",
+            "production_display",
+            "hall",
+            "hall_display",
+            "starts_at",
+            "ends_at",
+            "ticketing_url",
+            "prices",
+        }
         for f in expected:
             self.assertIn(f, data)
 
@@ -75,7 +85,17 @@ class TestEventSerializerFields(TestCase):
         serializer = EventSerializer(self.event, context={"request": _drf_request(self.factory, "/dummy")})
         self.assertEqual(
             set(serializer.data.keys()),
-            {"id", "production", "hall", "starts_at", "ends_at", "ticketing_url", "prices"},
+            {
+                "id",
+                "production",
+                "production_display",
+                "hall",
+                "hall_display",
+                "starts_at",
+                "ends_at",
+                "ticketing_url",
+                "prices",
+            },
         )
 
 

--- a/backend/tests/genres/test_genre_models.py
+++ b/backend/tests/genres/test_genre_models.py
@@ -43,10 +43,10 @@ class TestGenre:
 
     def test_str_representation_contains_translations(self):
         genre = GenreFactory(type="Festival")
-        GenreTranslationFactory(genre=genre, language__code="en", name="Festival")
-        GenreTranslationFactory(genre=genre, language__code="nl", name="Festival NL")
+        GenreTranslationFactory(genre=genre, language__code="en", name="EN Festival")
+        GenreTranslationFactory(genre=genre, language__code="nl", name="NL Festival")
 
-        assert str(genre) == "Festival"
+        assert str(genre) == "EN Festival (Festival)"
 
     def test_delete_cascades_to_translations(self):
         genre = GenreFactory()

--- a/backend/tests/genres/test_genre_serializers.py
+++ b/backend/tests/genres/test_genre_serializers.py
@@ -9,8 +9,9 @@ Covers:
 - Invalid data handling
 """
 
-from django.test import TestCase
-
+import pytest
+from rest_framework.test import APIRequestFactory
+from django.test import TestCase, override_settings
 from apps.genres.models import Genre, GenreTranslation, GenreUseAs
 from apps.genres.serializers import (
     GenreSerializer,
@@ -163,3 +164,37 @@ class TestGenreSerializerDeserialization(TestCase):
         updated = serializer.save()
         self.assertEqual(updated.type, "Festival")
         self.assertEqual(updated.use_as, self.use_as)
+
+def _display_ctx():
+        factory = APIRequestFactory()
+        return {"request": factory.get("/dummy")}
+
+class TestGenreDisplayNameBaseLanguage:
+    """Verify whether display_name uses base language with a sensible fallback."""
+    
+    @pytest.mark.django_db
+    @override_settings(LANGUAGE_CODE="en-us")
+    def test_uses_base_language_when_present(self):
+        en = Language.objects.create(code="en", name="English")
+        nl = Language.objects.create(code="nl", name="Dutch")
+
+        use_as = GenreUseAs.objects.create(name="genre")
+        genre = Genre.objects.create(type="festival", use_as=use_as)
+
+        GenreTranslation.objects.create(genre=genre, language=nl, name="Feest")
+        GenreTranslation.objects.create(genre=genre, language=en, name="Festival")
+
+        data = GenreSerializer(genre, context=_display_ctx()).data
+        assert data["display_name"] == "Festival"
+
+    @pytest.mark.django_db
+    @override_settings(LANGUAGE_CODE="en-us")
+    def test_falls_back_when_base_language_missing(self):
+        nl = Language.objects.create(code="nl", name="Dutch")
+
+        use_as = GenreUseAs.objects.create(name="genre")
+        genre = Genre.objects.create(type="festival", use_as=use_as)
+        GenreTranslation.objects.create(genre=genre, language=nl, name="Feest")
+
+        data = GenreSerializer(genre, context=_display_ctx()).data
+        assert data["display_name"] == "Feest"

--- a/backend/tests/genres/test_genre_serializers.py
+++ b/backend/tests/genres/test_genre_serializers.py
@@ -83,7 +83,7 @@ class TestGenreSerializerFields(TestCase):
 
     def test_expected_fields_are_present(self):
         data = GenreSerializer(self.genre).data
-        self.assertEqual(set(data.keys()), {"id", "type", "use_as", "name"})
+        self.assertEqual(set(data.keys()), {"id", "type", "use_as", "name", "display_name"})
 
 
 class TestGenreSerializerSerialization(TestCase):

--- a/backend/tests/locations/test_location_models.py
+++ b/backend/tests/locations/test_location_models.py
@@ -69,7 +69,7 @@ class TestSpace:
     def test_str_representation(self):
         loc = LocationFactory(city="Gotham", street="Main St", number="1")
         space = SpaceFactory(location=loc)
-        assert str(space) == f"Space {space.id} - {loc}"
+        assert str(space) == f"Space {space.id} @ {loc}"
 
     def test_reverse_relation_translations(self):
         space = SpaceFactory()

--- a/backend/tests/locations/test_location_serializers.py
+++ b/backend/tests/locations/test_location_serializers.py
@@ -7,8 +7,10 @@ Covers:
 - Queryset serialization for many=True
 """
 
+import pytest
+from django.test import override_settings
+from rest_framework.test import APIRequestFactory
 from django.test import TestCase
-
 from apps.languages.models import Language
 from apps.locations.models import Hall, Location, Space, LocationTranslation, SpaceTranslation, HallTranslation
 from apps.locations.serializers import HallSerializer, LocationSerializer, SpaceSerializer
@@ -121,3 +123,45 @@ class TestHallSerializerTranslations(TestCase):
 		data = HallSerializer(self.hall).data
 		self.assertEqual(data["name"], {"en": "Blue Hall", "fr": "Salle Bleue"})
 		self.assertEqual(data["remark"], {"en": "Front stage", "fr": "Avant scène"})
+
+
+def _ctx():
+    factory = APIRequestFactory()
+    return {"request": factory.get("/dummy")}
+
+
+def _make_hall():
+    loc = Location.objects.create(
+        street="Main St",
+        number="1",
+        postal_code="9000",
+        city="Ghent",
+        country="BE",
+        phone_1=None,
+        phone_2=None,
+        is_own_location=False,
+    )
+    space = Space.objects.create(location=loc)
+    return Hall.objects.create(space=space, seat_selection=False, open_seating=True)
+
+
+def _display_ctx():
+    factory = APIRequestFactory()
+    return {"request": factory.get("/dummy")}
+
+
+class TestHallDisplayNameBaseLanguage:
+    """Verify whether Hall's display_name uses base language."""
+
+    @pytest.mark.django_db
+    @override_settings(LANGUAGE_CODE="en-us")
+    def test_uses_base_language_when_present(self):
+        en = Language.objects.create(code="en", name="English")
+        nl = Language.objects.create(code="nl", name="Dutch")
+
+        hall = _make_hall()
+        HallTranslation.objects.create(hall=hall, language=nl, name="Grote Zaal", remark="Opmerking NL")
+        HallTranslation.objects.create(hall=hall, language=en, name="Main Hall", remark="Remark EN")
+
+        data = HallSerializer(hall, context=_display_ctx()).data
+        assert data["display_name"] == "Main Hall"

--- a/backend/tests/locations/test_location_serializers.py
+++ b/backend/tests/locations/test_location_serializers.py
@@ -44,6 +44,7 @@ class TestLocationSerializerFields(TestCase):
 				"phone_2",
 				"is_own_location",
 				"name",
+				"display_name"
 			},
 		)
 
@@ -76,7 +77,7 @@ class TestSpaceSerializerFields(TestCase):
 
 	def test_expected_fields_present(self):
 		data = SpaceSerializer(self.space).data
-		self.assertEqual(set(data.keys()), {"id", "location", "name"})
+		self.assertEqual(set(data.keys()), {"id", "location", "name", "display_name"})
 
 
 class TestSpaceSerializerTranslations(TestCase):
@@ -102,7 +103,7 @@ class TestHallSerializerFields(TestCase):
 		data = HallSerializer(self.hall).data
 		self.assertEqual(
 			set(data.keys()),
-			{"id", "space", "seat_selection", "open_seating", "name", "remark"},
+			{"id", "space", "seat_selection", "open_seating", "name", "display_name", "remark"},
 		)
 
 

--- a/backend/tests/media_library/test_media_library_serializers.py
+++ b/backend/tests/media_library/test_media_library_serializers.py
@@ -150,6 +150,7 @@ class TestMediaItemSerializerFields(TestCase):
             "width",
             "height",
             "title",
+            "display_title",
             "description",
             "credits",
             "link",
@@ -163,7 +164,7 @@ class TestMediaItemSerializerFields(TestCase):
         data = serialize_item(self.item)
         expected = {
             "id", "gallery", "type", "format", "original_filename", "position",
-            "width", "height", "title", "description", "credits", "link", "crops",
+            "width", "height", "title", "display_title", "description", "credits", "link", "crops",
         }
         self.assertEqual(set(data.keys()), expected)
 
@@ -407,7 +408,7 @@ class TestMediaGallerySerializerMediaItems(TestCase):
         data = serialize_gallery(self.gallery)
         expected = {
             "id", "gallery", "type", "format", "original_filename", "position",
-            "width", "height", "title", "description", "credits", "link", "crops",
+            "width", "height", "title", "display_title", "description", "credits", "link", "crops",
         }
         self.assertEqual(set(data["media_items"][0].keys()), expected)
 

--- a/backend/tests/pricing/test_pricing_serializers.py
+++ b/backend/tests/pricing/test_pricing_serializers.py
@@ -10,11 +10,13 @@ Covers:
 - PriceRankSerializer validation (unique position)
 """
 
-from django.test import TestCase
+import pytest
+from rest_framework.test import APIRequestFactory
+from django.test import TestCase, override_settings
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 from apps.languages.models import Language
-from apps.pricing.models import Price, PriceTranslation, PriceRank
+from apps.pricing.models import Price, PriceTranslation, PriceRank, PriceRankTranslation
 from apps.pricing.serializers import PriceSerializer, PriceRankSerializer
 
 
@@ -392,3 +394,36 @@ class TestPriceRankSerializer(TestCase):
         serializer = PriceRankSerializer(data={"position": "nope", "sold_out_buffer": 0})
         self.assertFalse(serializer.is_valid())
         self.assertIn("position", serializer.errors)
+
+
+def _display_ctx():
+    factory = APIRequestFactory()
+    return {"request": factory.get("/dummy")}
+
+
+class TestPriceRankDisplayDescriptionBaseLanguage:
+    """Verify whether display_description uses base language with a sensible fallback."""
+
+    @pytest.mark.django_db
+    @override_settings(LANGUAGE_CODE="en-us")
+    def test_uses_base_language_when_present(self):
+        en = Language.objects.create(code="en", name="English")
+        nl = Language.objects.create(code="nl", name="Dutch")
+
+        rank = PriceRank.objects.create(position=1, sold_out_buffer=0)
+        PriceRankTranslation.objects.create(price_rank=rank, language=nl, description="Standaard")
+        PriceRankTranslation.objects.create(price_rank=rank, language=en, description="Standard")
+
+        data = PriceRankSerializer(rank, context=_display_ctx()).data
+        assert data["display_description"] == "Standard"
+
+    @pytest.mark.django_db
+    @override_settings(LANGUAGE_CODE="en-us")
+    def test_falls_back_when_base_language_missing(self):
+        nl = Language.objects.create(code="nl", name="Dutch")
+
+        rank = PriceRank.objects.create(position=1, sold_out_buffer=0)
+        PriceRankTranslation.objects.create(price_rank=rank, language=nl, description="Standaard")
+
+        data = PriceRankSerializer(rank, context=_display_ctx()).data
+        assert data["display_description"] == "Standaard"

--- a/backend/tests/pricing/test_pricing_serializers.py
+++ b/backend/tests/pricing/test_pricing_serializers.py
@@ -92,6 +92,7 @@ class TestPriceSerializerFields(TestCase):
                 "sort_order",
                 "cineville_box",
                 "description",
+                "display_description"
             },
         )
 

--- a/backend/tests/productions/test_production_serializers.py
+++ b/backend/tests/productions/test_production_serializers.py
@@ -154,7 +154,8 @@ class TestProductionSerializerFields(TestCase):
             "id", "attendance_mode", "performer_type",
             "uit_database_theme", "uit_database_type",
             "title", "description", "teaser", "artist_name", "tagline",
-            "tags", "genres",
+            "tags", "genres", "display_title",
+            "display_artist_name"
         }
         self.assertEqual(set(data.keys()), expected)
 

--- a/backend/tests/productions/test_production_views.py
+++ b/backend/tests/productions/test_production_views.py
@@ -139,7 +139,7 @@ class TestProductionViewSetList(TestCase):
             "id", "attendance_mode", "performer_type",
             "uit_database_theme", "uit_database_type",
             "title", "description", "teaser", "artist_name", "tagline",
-            "tags", "genres"
+            "tags", "genres", "display_title", "display_artist_name",
         }
         self.assertEqual(set(item.keys()), expected_fields)
 

--- a/backend/tests/tags/test_tag_models.py
+++ b/backend/tests/tags/test_tag_models.py
@@ -42,12 +42,12 @@ class TestTag:
     def test_empty_type(self):
         tag = TagFactory.build(type="")
         
-        # The model should allow empty type, so full_clean should not raise an error
-        tag.full_clean()  # should not raise
+        tag.full_clean()
 
     def test_str_representation(self):
         tag = TagFactory(type="genre")
-        assert str(tag) == "Tag of type (genre)"
+        TagTranslationFactory(tag=tag, language__code="en", name="Rock")
+        assert str(tag) == "Rock"
 
     def test_delete_cascades_to_translations(self):
         tag = TagFactory()

--- a/backend/tests/tags/test_tag_serializers.py
+++ b/backend/tests/tags/test_tag_serializers.py
@@ -12,8 +12,9 @@ Covers:
 - Field types
 """
 
-from django.test import TestCase
-
+import pytest
+from django.test import TestCase, override_settings
+from rest_framework.test import APIRequestFactory
 from apps.languages.models import Language
 from apps.tags.models import Tag, TagTranslation
 from apps.tags.serializers import TagSerializer
@@ -306,3 +307,50 @@ class TestTagSerializerDeserialization(TestCase):
         self.assertTrue(serializer.is_valid())
         updated = serializer.save()
         self.assertEqual(updated.source, "manual")
+
+
+def _display_ctx():
+    factory = APIRequestFactory()
+    return {"request": factory.get("/dummy")}
+
+
+class TestTagDisplayNameBaseLanguage:
+    """Verify whether display_name uses base language with a sensible fallback."""
+
+    @pytest.mark.django_db
+    @override_settings(LANGUAGE_CODE="en-us")
+    def test_uses_base_language_when_present(self):
+        en = Language.objects.create(code="en", name="English")
+        nl = Language.objects.create(code="nl", name="Dutch")
+
+        tag = Tag.objects.create(
+            url="",
+            source="system",
+            source_type="",
+            type="theme",
+            is_external=False,
+            is_enabled=True,
+        )
+        TagTranslation.objects.create(tag=tag, language=nl, name="Thema", short_description="", url_title="")
+        TagTranslation.objects.create(tag=tag, language=en, name="Theme", short_description="", url_title="")
+
+        data = TagSerializer(tag, context=_display_ctx()).data
+        assert data["display_name"] == "Theme"
+
+    @pytest.mark.django_db
+    @override_settings(LANGUAGE_CODE="en-us")
+    def test_falls_back_when_base_language_missing(self):
+        nl = Language.objects.create(code="nl", name="Dutch")
+
+        tag = Tag.objects.create(
+            url="",
+            source="system",
+            source_type="",
+            type="theme",
+            is_external=False,
+            is_enabled=True,
+        )
+        TagTranslation.objects.create(tag=tag, language=nl, name="Thema", short_description="", url_title="")
+
+        data = TagSerializer(tag, context=_display_ctx()).data
+        assert data["display_name"] == "Thema"

--- a/backend/tests/tags/test_tag_serializers.py
+++ b/backend/tests/tags/test_tag_serializers.py
@@ -60,8 +60,8 @@ class TestTagSerializerFields(TestCase):
     def test_no_extra_fields_are_exposed(self):
         serializer = TagSerializer(self.tag)
         expected = {"id", "url", "source", "source_type", "type",
-                    "is_external", "is_enabled", "name",
-                    "short_description", "url_title"}
+            "is_external", "is_enabled", "name", "display_name", "display_short_description", "display_url_title",
+            "short_description", "url_title"}
         self.assertEqual(set(serializer.data.keys()), expected)
 
 


### PR DESCRIPTION
_Related to issue #116_ 

## Summary

This pull request implements the requirements of the issue by ensuring that base-language display strings are consistently used across the admin interface and API responses.

Changes included:

- Added base-language `display_*` fields (e.g. `display_name`, `display_title`, `display_description`) to serializers where applicable, while preserving full translation dictionaries.
- Updated model `__str__` methods so Django admin uses the base-language representation (with sensible fallbacks to avoid duplicate labels like `X (X)`).
- Updated existing tests that validate serializer field exposure to account for the newly introduced `display_*` fields.
- Added targeted serializer tests to verify that `display_*` fields:
  - use the base language when available (derived from `settings.LANGUAGE_CODE`), and
  - fall back to the first available translation when the base language translation is missing.

## Notes

- Run the full test suite to ensure no regressions were introduced.
- Verify that the end goal of the issue is met:
  - Admin uses base-language strings via `__str__`
  - API exposes base-language display strings via `display_*` fields while keeping full translation data.