### PR TITLE
Revert "chore(deps)(deps-dev): bump eslint-plugin-react-refresh from 0.4.26 to 0.5.2 in /frontend in the patch-minor-updates group"

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,7 +33,7 @@
                 "eslint-plugin-prettier": "^5.2.1",
                 "eslint-plugin-react": "^7.35.0",
                 "eslint-plugin-react-hooks": "^7.0.1",
-                "eslint-plugin-react-refresh": "^0.5.2",
+                "eslint-plugin-react-refresh": "^0.4.12",
                 "globals": "^15.9.0",
                 "identity-obj-proxy": "^3.0.0",
                 "jest": "^30.2.0",
@@ -5529,13 +5529,13 @@
             }
         },
         "node_modules/eslint-plugin-react-refresh": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.2.tgz",
-            "integrity": "sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==",
+            "version": "0.4.26",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.26.tgz",
+            "integrity": "sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
-                "eslint": "^9 || ^10"
+                "eslint": ">=8.40"
             }
         },
         "node_modules/eslint-plugin-react/node_modules/balanced-match": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
         "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-react": "^7.35.0",
         "eslint-plugin-react-hooks": "^7.0.1",
-        "eslint-plugin-react-refresh": "^0.5.2",
+        "eslint-plugin-react-refresh": "^0.4.12",
         "globals": "^15.9.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^30.2.0",


### PR DESCRIPTION
Reverts SELab-2/viernulvier-2#145