### PR TITLE
Add ignore-checks to gatekeeper workflow

### DIFF
--- a/.github/workflows/gatekeeper.yml
+++ b/.github/workflows/gatekeeper.yml
@@ -30,6 +30,7 @@ jobs:
           check-name: 'Django check + Pytest'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
+          ignore-checks: 'CI Gatekeeper'
 
   frontend-gate:
     name: Lint / Test / Build
@@ -56,3 +57,4 @@ jobs:
           check-name: 'Lint / Test / Build'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
+          ignore-checks: 'CI Gatekeeper'


### PR DESCRIPTION
With ignore checks: ‘CI Gatekeeper’ only looks at the results of the other workflows (Frontend and Backend CI). Once they are set to “Success,” the Gatekeeper will see that it can stop and set itself to “Success” as well.