### PR TITLE
chore: remove dependabot-test branch from CI workflows

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,7 +2,7 @@ name: Dependabot auto-merge
 
 on:
   pull_request_target:
-    branches: [main, dev, dependabot-test]
+    branches: [main, dev]
 
 permissions:
   contents: write

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -2,10 +2,10 @@ name: Frontend CI
 
 on:
   push:
-    branches: [main, dev, frontend, dependabot-test]
+    branches: [main, dev, frontend]
     paths: [frontend/**]
   pull_request:
-    branches: [main, dev, frontend, dependabot-test]
+    branches: [main, dev, frontend]
     paths: [frontend/**]
 
 concurrency:


### PR DESCRIPTION
Just removed the dependabot-test branch from the workflows since it no longer exists.