### PR TITLE
Add LoadingSpinner component with customizable properties and tests

### DIFF
--- a/frontend/src/__tests__/LoadingSpinner.test.tsx
+++ b/frontend/src/__tests__/LoadingSpinner.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react'
+import { ThemeProvider, createTheme } from '@mui/material/styles'
+import LoadingSpinner from '../components/LoadingSpinner'
+
+const renderWithTheme = (mode: 'light' | 'dark') => {
+  const theme = createTheme({
+    palette: {
+      mode,
+    },
+  })
+
+  return {
+    theme,
+    ...render(
+      <ThemeProvider theme={theme}>
+        <LoadingSpinner />
+      </ThemeProvider>,
+    ),
+  }
+}
+
+describe('LoadingSpinner', () => {
+  it('renders with default label and status attributes', () => {
+    render(<LoadingSpinner />)
+
+    const spinner = screen.getByTestId('loading-spinner')
+    expect(spinner).toBeInTheDocument()
+    expect(spinner).toHaveAttribute('role', 'status')
+    expect(spinner).toHaveAttribute('aria-label', 'Loading')
+    expect(screen.getByText('Loading')).toBeInTheDocument()
+  })
+
+  it('uses the active theme text color by default', () => {
+    const { theme } = renderWithTheme('dark')
+
+    expect(screen.getByText('Loading')).toHaveStyle({ color: theme.palette.text.primary })
+  })
+
+  it('supports custom label, size, and fullscreen layout', () => {
+    render(<LoadingSpinner label="Fetching events" size={48} fullScreen />)
+
+    const spinner = screen.getByTestId('loading-spinner')
+    expect(spinner).toHaveAttribute('aria-label', 'Fetching events')
+    expect(screen.getByText('Fetching events')).toBeInTheDocument()
+    expect(spinner).toHaveStyle({ width: '100vw', minHeight: '100vh' })
+  })
+
+  it('prefers an explicit color over the theme default', () => {
+    renderWithTheme('light')
+    render(<LoadingSpinner color="#ff5500" label="Custom color" />)
+
+    expect(screen.getByText('Custom color')).toHaveStyle({ color: '#ff5500' })
+  })
+})

--- a/frontend/src/__tests__/LoadingSpinner.test.tsx
+++ b/frontend/src/__tests__/LoadingSpinner.test.tsx
@@ -1,8 +1,9 @@
+import type { ReactNode } from 'react'
 import { render, screen } from '@testing-library/react'
 import { ThemeProvider, createTheme } from '@mui/material/styles'
 import LoadingSpinner from '../components/LoadingSpinner'
 
-const renderWithTheme = (mode: 'light' | 'dark') => {
+const renderWithTheme = (mode: 'light' | 'dark', ui: ReactNode = <LoadingSpinner />) => {
   const theme = createTheme({
     palette: {
       mode,
@@ -11,11 +12,7 @@ const renderWithTheme = (mode: 'light' | 'dark') => {
 
   return {
     theme,
-    ...render(
-      <ThemeProvider theme={theme}>
-        <LoadingSpinner />
-      </ThemeProvider>,
-    ),
+    ...render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>),
   }
 }
 
@@ -42,12 +39,15 @@ describe('LoadingSpinner', () => {
     const spinner = screen.getByTestId('loading-spinner')
     expect(spinner).toHaveAttribute('aria-label', 'Fetching events')
     expect(screen.getByText('Fetching events')).toBeInTheDocument()
-    expect(spinner).toHaveStyle({ width: '100vw', minHeight: '100vh' })
+    expect(spinner).toHaveStyle({ position: 'fixed', inset: '0' })
+
+    // Verify size={48} is forwarded to the CircularProgress element.
+    const progress = screen.getByRole('progressbar')
+    expect(progress).toHaveStyle({ width: '48px', height: '48px' })
   })
 
   it('prefers an explicit color over the theme default', () => {
-    renderWithTheme('light')
-    render(<LoadingSpinner color="#ff5500" label="Custom color" />)
+    renderWithTheme('light', <LoadingSpinner color="#ff5500" label="Custom color" />)
 
     expect(screen.getByText('Custom color')).toHaveStyle({ color: '#ff5500' })
   })

--- a/frontend/src/components/LoadingSpinner.tsx
+++ b/frontend/src/components/LoadingSpinner.tsx
@@ -23,14 +23,27 @@ const LoadingSpinner = ({
       aria-live="polite"
       aria-label={label}
       data-testid="loading-spinner"
-      sx={{
-        width: fullScreen ? '100vw' : 'auto',
-        minHeight: fullScreen ? '100vh' : 'auto',
-        display: 'grid',
-        placeItems: 'center',
-        textAlign: 'center',
-        gap: 1,
-      }}
+      sx={
+        fullScreen
+          ? {
+              position: 'fixed',
+              inset: 0,
+              zIndex: theme.zIndex.modal,
+              bgcolor: theme.palette.background.default,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 1,
+            }
+          : {
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 1,
+            }
+      }
     >
       <CircularProgress size={size} sx={{ color: resolvedColor }} />
       <Typography

--- a/frontend/src/components/LoadingSpinner.tsx
+++ b/frontend/src/components/LoadingSpinner.tsx
@@ -1,0 +1,50 @@
+import { Box, CircularProgress, Typography } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+
+type LoadingSpinnerProps = {
+  size?: number
+  color?: string
+  label?: string
+  fullScreen?: boolean
+}
+
+const LoadingSpinner = ({
+  size = 36,
+  color,
+  label = 'Loading',
+  fullScreen = false,
+}: LoadingSpinnerProps) => {
+  const theme = useTheme()
+  const resolvedColor = color ?? theme.palette.text.primary
+
+  return (
+    <Box
+      role="status"
+      aria-live="polite"
+      aria-label={label}
+      data-testid="loading-spinner"
+      sx={{
+        width: fullScreen ? '100vw' : 'auto',
+        minHeight: fullScreen ? '100vh' : 'auto',
+        display: 'grid',
+        placeItems: 'center',
+        textAlign: 'center',
+        gap: 1,
+      }}
+    >
+      <CircularProgress size={size} sx={{ color: resolvedColor }} />
+      <Typography
+        variant="body2"
+        sx={{
+          color: resolvedColor,
+          fontSize: '0.85rem',
+          opacity: 0.85,
+        }}
+      >
+        {label}
+      </Typography>
+    </Box>
+  )
+}
+
+export default LoadingSpinner


### PR DESCRIPTION
# LoadingSpinner Component

## Summary

The component is built with MUI, uses the selected ring loader style, and automatically follows the active light/dark theme unless a custom `color` prop is passed.

## Changes

- Added a reusable `LoadingSpinner` component in `frontend/src/components/LoadingSpinner.tsx`
- Added tests for accessibility, fullscreen layout, theme-aware coloring, and custom color overrides

## How To Use

Import the component:

```tsx
import LoadingSpinner from '../components/LoadingSpinner'
```

Basic usage:

```tsx
<LoadingSpinner />
```

With a custom label:

```tsx
<LoadingSpinner label="Loading archive..." />
```

Fullscreen usage:

```tsx
<LoadingSpinner label="Fetching events..." fullScreen />
```

Custom size or color:

```tsx
<LoadingSpinner size={48} color="#d32f2f" label="Loading..." />
```

## Props

- `size?: number`
- `color?: string`
- `label?: string`
- `fullScreen?: boolean`

## Theme Behavior

By default, the spinner uses the active MUI theme text color:

- In light mode it uses the light theme text color
- In dark mode it uses the dark theme text color

If a `color` prop is provided, that value overrides the theme-based default.

## How To Test

To verify the component visually, temporarily add it to any page (e.g. `HomePage.tsx`) while running the dev server:

```tsx
import LoadingSpinner from '../components/LoadingSpinner'

// Inside the JSX:
<LoadingSpinner label="Loading archive..." />
```

Then:

1. Start the frontend with `npm run dev` from `frontend/`
2. Open the page in a browser
3. Confirm the ring spinner is visible
4. Toggle between light and dark mode using the navbar button
5. Confirm the spinner color changes with the theme