### PR TITLE
A production object from the API has no media_gallery field

### DIFF
--- a/backend/apps/productions/schemas.py
+++ b/backend/apps/productions/schemas.py
@@ -38,6 +38,7 @@ _PRODUCTION_RESPONSE = OpenApiExample(
         "id": 1,
         "attendance_mode": "offline",
         "performer_type": "group",
+        "media_gallery": 4,
         "uit_database_theme": {"id": 3, "name": "Theater"},
         "uit_database_type": {"id": 7, "name": "Voorstelling"},
         "title": "De Laatste Avond",

--- a/backend/apps/productions/serializers.py
+++ b/backend/apps/productions/serializers.py
@@ -166,6 +166,7 @@ class ProductionSerializer(TranslatableSerializerMixin, serializers.ModelSeriali
             "id",
             "attendance_mode",
             "performer_type",
+            "media_gallery",
             "uit_database_theme",
             "uit_database_type",
             "display_title",
@@ -198,6 +199,9 @@ class ProductionSerializer(TranslatableSerializerMixin, serializers.ModelSeriali
             },
             "performer_type": {
                 "help_text": ("Whether the performance is by a group or a solo artist. Accepted values: `group`, `solo`."),
+            },
+            "media_gallery": {
+                "help_text": "PK of the associated MediaGallery. `null` when no gallery is assigned.",
             },
         }
 

--- a/backend/apps/productions/views.py
+++ b/backend/apps/productions/views.py
@@ -90,6 +90,7 @@ class ProductionViewSet(ApiModelViewSet):
     queryset = Production.objects.select_related(
         "uit_database_theme",
         "uit_database_type",
+        "media_gallery",
     ).prefetch_related(
         "translations__language",
         "tags",

--- a/backend/tests/productions/test_production_serializers.py
+++ b/backend/tests/productions/test_production_serializers.py
@@ -25,6 +25,7 @@ from apps.productions.serializers import (
     UitDatabaseTypeSerializer,
 )
 from tests.factories.language import LanguageFactory
+from tests.factories.media_library import MediaGalleryFactory
 from tests.factories.production import (
     ProductionFactory,
     ProductionTranslationFactory,
@@ -108,6 +109,7 @@ class TestProductionSerializerFields(TestCase):
             "id",
             "attendance_mode",
             "performer_type",
+            "media_gallery",
             "uit_database_theme",
             "uit_database_type",
             "title",
@@ -126,6 +128,7 @@ class TestProductionSerializerFields(TestCase):
             "id",
             "attendance_mode",
             "performer_type",
+            "media_gallery",
             "uit_database_theme",
             "uit_database_type",
             "title",
@@ -148,6 +151,17 @@ class TestProductionSerializerFields(TestCase):
 
 class TestProductionSerializerScalarFields(TestCase):
     """Model -> dict for non-translated, non-nested fields."""
+
+    def test_serializes_media_gallery_correctly(self):
+        gallery = MediaGalleryFactory.create()
+        production = ProductionFactory.create(media_gallery=gallery)
+        data = ProductionSerializer(production).data
+        self.assertEqual(data["media_gallery"], gallery.id)
+
+    def test_serializes_null_media_gallery_correctly(self):
+        production = ProductionFactory.create(media_gallery=None)
+        data = ProductionSerializer(production).data
+        self.assertIsNone(data["media_gallery"])
 
     def test_serializes_attendance_mode_correctly(self):
         production = ProductionFactory.create(attendance_mode="offline")

--- a/backend/tests/productions/test_production_views.py
+++ b/backend/tests/productions/test_production_views.py
@@ -118,6 +118,7 @@ class TestProductionViewSetList(TestCase):
             "id",
             "attendance_mode",
             "performer_type",
+            "media_gallery",
             "uit_database_theme",
             "uit_database_type",
             "title",


### PR DESCRIPTION
## Description
Add media_gallery field to ProductionSerializer

## Related Issues
- Fixes #269

## Type of Change
- [x] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please specify): _____________

## Testing Instructions
- Run tests and make sure they pass
- Fetch productions using the API and verify that the `media_gallery` field is available

## Checklist for Reviewers
- [ ] Follows Style Guide
- [ ] Has Documentation (if applicable)
- [ ] Added Unit tests
- [ ] Tested in the relevant environments
