### PR TITLE
Update CI configuration to skip covered lines in coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         run: python manage.py makemigrations --check --dry-run
 
       - name: Run tests with coverage
-        run: pytest -q --cov=. --cov-report=term-missing --cov-report=html
+        run: pytest -q --cov=. --cov-report=term-missing:skip-covered --cov-report=html
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
This pull request makes a minor update to the test coverage reporting configuration in the CI workflow. The change modifies the pytest command to skip displaying coverage details for files that are fully covered, making the coverage output more concise.

- CI workflow improvement:
  * Updated the pytest coverage command in `.github/workflows/ci.yml` to use `--cov-report=term-missing:skip-covered`, which omits coverage details for files with 100% coverage.