### PR TITLE
[FE] Minor changes related to SeriesDetailPage

### DIFF
--- a/frontend/src/__tests__/components/series_details/ProductionCard.test.tsx
+++ b/frontend/src/__tests__/components/series_details/ProductionCard.test.tsx
@@ -11,7 +11,7 @@ describe('ProductionCard', () => {
     tags: [
       { id: 1, name: 'Festival', labels: { nl: 'Festival', en: 'Festival' } },
       { id: 2, name: 'Audiovisueel', labels: { nl: 'Audiovisueel', en: 'Audiovisual' } },
-      { id: 3, name: '3 dagen', labels: { nl: '3 dagen', en: '3 days' } },
+      { id: 3, name: 'Performance', labels: { nl: 'Performance', en: 'Performance' } },
     ],
   }
 
@@ -23,39 +23,35 @@ describe('ProductionCard', () => {
     )
   }
 
-  it('renders title, meta, description and tags', () => {
+  it('renders title, meta, description and genres', () => {
     renderCard()
 
     expect(screen.getByText(defaultProps.title)).toBeInTheDocument()
     expect(screen.getByText(defaultProps.meta)).toBeInTheDocument()
     expect(screen.getByText(defaultProps.description)).toBeInTheDocument()
 
-    defaultProps.tags.forEach((tag) => {
-      expect(screen.getByText(tag.name)).toBeInTheDocument()
+    defaultProps.tags.forEach((genre) => {
+      expect(screen.getByText(genre.name)).toBeInTheDocument()
     })
   })
 
-  it('renders all provided tags as clickable chips', () => {
-    const tags = [
+  it('renders all provided genres as chips', () => {
+    const genres = [
       { id: 1, name: 'Festival', labels: { nl: 'Festival', en: 'Festival' } },
       { id: 2, name: 'Live visuals', labels: { nl: 'Live visuals', en: 'Live visuals' } },
-      { id: 3, name: '25 artiesten', labels: { nl: '25 artiesten', en: '25 artists' } },
-      { id: 4, name: '3 dagen', labels: { nl: '3 dagen', en: '3 days' } },
+      { id: 3, name: 'Audiovisueel', labels: { nl: 'Audiovisueel', en: 'Audiovisual' } },
+      { id: 4, name: 'Performance', labels: { nl: 'Performance', en: 'Performance' } },
     ]
 
     renderCard({
       title: 'VIDEODROOM 2023',
       meta: '10e editie',
       description: 'Beschrijving',
-      tags,
+      tags: genres,
     })
 
-    tags.forEach((tag) => {
-      expect(screen.getByText(tag.name)).toBeInTheDocument()
+    genres.forEach((genre) => {
+      expect(screen.getByText(genre.name)).toBeInTheDocument()
     })
-
-    const links = screen.getAllByRole('link')
-    expect(links).toHaveLength(tags.length)
-    expect(links[0]).toHaveAttribute('href', '/series/1')
   })
 })

--- a/frontend/src/__tests__/components/series_details/ProductionCard.test.tsx
+++ b/frontend/src/__tests__/components/series_details/ProductionCard.test.tsx
@@ -8,10 +8,13 @@ describe('ProductionCard', () => {
     title: 'VIDEODROOM 2024',
     meta: '11e editie · 3–5 mei 2024',
     description: 'Een audiovisuele editie met live visuals en performances.',
-    tags: [
-      { id: 1, name: 'Festival', labels: { nl: 'Festival', en: 'Festival' } },
-      { id: 2, name: 'Audiovisueel', labels: { nl: 'Audiovisueel', en: 'Audiovisual' } },
-      { id: 3, name: 'Performance', labels: { nl: 'Performance', en: 'Performance' } },
+    genres: [
+      { id: 1, name: 'Audiovisueel', labels: { nl: 'Audiovisueel', en: 'Audiovisual' } },
+      { id: 2, name: 'Performance', labels: { nl: 'Performance', en: 'Performance' } },
+    ],
+    seriesTags: [
+      { id: 10, name: 'VIDEODROOM', labels: { nl: 'VIDEODROOM', en: 'VIDEODROOM' } },
+      { id: 11, name: 'Festivalreeks', labels: { nl: 'Festivalreeks', en: 'Festival series' } },
     ],
   }
 
@@ -23,35 +26,66 @@ describe('ProductionCard', () => {
     )
   }
 
-  it('renders title, meta, description and genres', () => {
+  it('renders title, meta, description, genres and series tags', () => {
     renderCard()
 
     expect(screen.getByText(defaultProps.title)).toBeInTheDocument()
     expect(screen.getByText(defaultProps.meta)).toBeInTheDocument()
     expect(screen.getByText(defaultProps.description)).toBeInTheDocument()
 
-    defaultProps.tags.forEach((genre) => {
+    defaultProps.genres.forEach((genre) => {
       expect(screen.getByText(genre.name)).toBeInTheDocument()
+    })
+
+    defaultProps.seriesTags.forEach((tag) => {
+      expect(screen.getByText(tag.name)).toBeInTheDocument()
     })
   })
 
-  it('renders all provided genres as chips', () => {
-    const genres = [
-      { id: 1, name: 'Festival', labels: { nl: 'Festival', en: 'Festival' } },
-      { id: 2, name: 'Live visuals', labels: { nl: 'Live visuals', en: 'Live visuals' } },
-      { id: 3, name: 'Audiovisueel', labels: { nl: 'Audiovisueel', en: 'Audiovisual' } },
-      { id: 4, name: 'Performance', labels: { nl: 'Performance', en: 'Performance' } },
-    ]
+  it('renders genre chips and clickable series tag chips', () => {
+    renderCard()
 
+    expect(screen.getByText('Audiovisueel')).toBeInTheDocument()
+    expect(screen.getByText('Performance')).toBeInTheDocument()
+
+    const seriesLinks = screen.getAllByRole('link')
+    expect(seriesLinks).toHaveLength(defaultProps.seriesTags.length)
+    expect(seriesLinks[0]).toHaveAttribute('href', '/series/10')
+    expect(seriesLinks[1]).toHaveAttribute('href', '/series/11')
+  })
+
+  it('renders only genres when no series tags are provided', () => {
     renderCard({
       title: 'VIDEODROOM 2023',
       meta: '10e editie',
       description: 'Beschrijving',
-      tags: genres,
+      genres: [
+        { id: 1, name: 'Live visuals', labels: { nl: 'Live visuals', en: 'Live visuals' } },
+        { id: 2, name: 'Experimenteel', labels: { nl: 'Experimenteel', en: 'Experimental' } },
+      ],
+      seriesTags: [],
     })
 
-    genres.forEach((genre) => {
-      expect(screen.getByText(genre.name)).toBeInTheDocument()
+    expect(screen.getByText('Live visuals')).toBeInTheDocument()
+    expect(screen.getByText('Experimenteel')).toBeInTheDocument()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+
+  it('renders only series tags when no genres are provided', () => {
+    renderCard({
+      title: 'VIDEODROOM 2022',
+      meta: '9e editie',
+      description: 'Beschrijving',
+      genres: [],
+      seriesTags: [
+        { id: 30, name: 'Retrospectieve', labels: { nl: 'Retrospectieve', en: 'Retrospective' } },
+      ],
     })
+
+    expect(screen.getByText('Retrospectieve')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Retrospectieve' })).toHaveAttribute(
+      'href',
+      '/series/30',
+    )
   })
 })

--- a/frontend/src/__tests__/pages/SeriesDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/SeriesDetailPage.test.tsx
@@ -90,6 +90,7 @@ describe('SeriesDetailPage', () => {
           teaser: { nl: 'Beschrijving productie' },
           description: { nl: 'Beschrijving productie' },
           artist_name: { nl: 'Artiest' },
+          genres: [],
           tags: [],
         },
       ],
@@ -185,6 +186,7 @@ describe('SeriesDetailPage', () => {
           teaser: { nl: 'Beschrijving productie' },
           description: { nl: 'Beschrijving productie' },
           artist_name: { nl: 'Artiest' },
+          genres: [],
           tags: [],
         },
       ],
@@ -196,5 +198,51 @@ describe('SeriesDetailPage', () => {
     fireEvent.click(productionCard)
 
     expect(await screen.findByText('PRODUCTION DETAIL')).toBeInTheDocument()
+  })
+
+  it('renders production genres in the production card', async () => {
+    mockedGetTag.mockResolvedValue({
+      id: 1,
+      name: { nl: 'VIDEODROOM' },
+      short_description: { nl: 'Beschrijving van de reeks' },
+      type: 'festival',
+    })
+
+    mockedGetProductions.mockResolvedValue({
+      results: [
+        {
+          id: 1,
+          display_title: 'VIDEODROOM 2024',
+          title: { nl: 'VIDEODROOM 2024' },
+          teaser: { nl: 'Beschrijving productie' },
+          description: { nl: 'Beschrijving productie' },
+          artist_name: { nl: 'Artiest' },
+          genres: [
+            {
+              id: 10,
+              type: 'genre',
+              use_as: { id: 1, name: 'genre' },
+              name: { nl: 'Audiovisueel', en: 'Audiovisual' },
+              display_name: null,
+              vendor_id: null,
+            },
+            {
+              id: 11,
+              type: 'genre',
+              use_as: { id: 1, name: 'genre' },
+              name: { nl: 'Performance', en: 'Performance' },
+              display_name: null,
+              vendor_id: null,
+            },
+          ],
+          tags: [],
+        },
+      ],
+    })
+
+    renderPage()
+
+    expect(await screen.findByText('Audiovisueel')).toBeInTheDocument()
+    expect(screen.getByText('Performance')).toBeInTheDocument()
   })
 })

--- a/frontend/src/__tests__/pages/SeriesDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/SeriesDetailPage.test.tsx
@@ -200,7 +200,7 @@ describe('SeriesDetailPage', () => {
     expect(await screen.findByText('PRODUCTION DETAIL')).toBeInTheDocument()
   })
 
-  it('renders production genres in the production card', async () => {
+  it('renders both production genres and series tags in the production card', async () => {
     mockedGetTag.mockResolvedValue({
       id: 1,
       name: { nl: 'VIDEODROOM' },
@@ -235,7 +235,20 @@ describe('SeriesDetailPage', () => {
               vendor_id: null,
             },
           ],
-          tags: [],
+          tags: [
+            {
+              id: 20,
+              name: { nl: 'Festivalreeks', en: 'Festival series' },
+              display_name: null,
+              type: 'series',
+            },
+            {
+              id: 21,
+              name: { nl: 'Videodroom', en: 'Videodroom' },
+              display_name: null,
+              type: 'series',
+            },
+          ],
         },
       ],
     })
@@ -244,5 +257,13 @@ describe('SeriesDetailPage', () => {
 
     expect(await screen.findByText('Audiovisueel')).toBeInTheDocument()
     expect(screen.getByText('Performance')).toBeInTheDocument()
+    expect(screen.getByText('Festivalreeks')).toBeInTheDocument()
+    expect(screen.getByText('Videodroom')).toBeInTheDocument()
+
+    expect(screen.getByRole('link', { name: 'Festivalreeks' })).toHaveAttribute(
+      'href',
+      '/series/20',
+    )
+    expect(screen.getByRole('link', { name: 'Videodroom' })).toHaveAttribute('href', '/series/21')
   })
 })

--- a/frontend/src/__tests__/pages/SeriesDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/SeriesDetailPage.test.tsx
@@ -18,12 +18,12 @@ jest.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => {
       const translations: Record<string, string> = {
-        'series.loading': 'Reeks wordt geladen...',
+        'series.loading': 'Reeks laden',
         'series.backToSeries': 'Terug naar reeksen',
         'series.allEditions': 'Alle edities',
         'series.allEditionsSubtitle':
           'Chronologisch overzicht van de producties binnen deze reeks.',
-        'series.noProductions': 'Er zijn nog geen producties gekoppeld aan deze reeks.',
+        'series.noProductions': 'Er zijn geen producties gekoppeld aan deze reeks.',
         'series.invalidId': 'Ongeldig reeks-ID.',
         'series.fetchError': 'Kon de reeks niet ophalen.',
         'series.noDescription': 'Geen beschrijving beschikbaar.',
@@ -70,7 +70,7 @@ describe('SeriesDetailPage', () => {
     renderPage()
 
     expect(screen.getByTestId('loading-spinner')).toBeInTheDocument()
-    expect(screen.getByText('Reeks wordt geladen...')).toBeInTheDocument()
+    expect(screen.getByText('Reeks laden')).toBeInTheDocument()
   })
 
   it('renders series data when API succeeds', async () => {
@@ -156,7 +156,7 @@ describe('SeriesDetailPage', () => {
     renderPage()
 
     expect(
-      await screen.findByText('Er zijn nog geen producties gekoppeld aan deze reeks.'),
+      await screen.findByText('Er zijn geen producties gekoppeld aan deze reeks.'),
     ).toBeInTheDocument()
   })
 

--- a/frontend/src/components/series_details/ProductionCard.tsx
+++ b/frontend/src/components/series_details/ProductionCard.tsx
@@ -1,5 +1,5 @@
 /*
- * Displays a single production with metadata, description and tags.
+ * Displays a single production with metadata, description, genres and series tags.
  * Designed to be reusable across different pages (lists, search, etc.).
  */
 
@@ -8,7 +8,7 @@ import DOMPurify from 'dompurify'
 import type { KeyboardEvent, MouseEvent } from 'react'
 import GenreAndTagChip from '../chips/GenreAndTagChip'
 
-type ProductionTag = {
+type ProductionChip = {
   id: number | string
   name: string
   labels?: Record<string, string>
@@ -19,11 +19,12 @@ type Props = {
   title: string
   meta: string
   description: string
-  tags: ProductionTag[]
+  genres: ProductionChip[]
+  seriesTags: ProductionChip[]
   onClick?: (event: MouseEvent<HTMLDivElement>) => void
 }
 
-const ProductionCard = ({ title, meta, description, tags, onClick }: Props) => {
+const ProductionCard = ({ title, meta, description, genres, seriesTags, onClick }: Props) => {
   const isInteractive = typeof onClick === 'function'
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -86,14 +87,25 @@ const ProductionCard = ({ title, meta, description, tags, onClick }: Props) => {
           />
 
           <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
-            {tags.map((genre) => (
+            {genres.map((genre) => (
               <GenreAndTagChip
-                key={genre.id}
+                key={`genre-${genre.id}`}
                 name={genre.name}
                 labels={genre.labels ?? {}}
                 id={genre.id}
                 chipType="genre"
                 context="static"
+              />
+            ))}
+
+            {seriesTags.map((tag) => (
+              <GenreAndTagChip
+                key={`tag-${tag.id}`}
+                name={tag.name}
+                labels={tag.labels ?? {}}
+                id={tag.id}
+                chipType="seriesTag"
+                context="series"
               />
             ))}
           </Stack>

--- a/frontend/src/components/series_details/ProductionCard.tsx
+++ b/frontend/src/components/series_details/ProductionCard.tsx
@@ -86,14 +86,14 @@ const ProductionCard = ({ title, meta, description, tags, onClick }: Props) => {
           />
 
           <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
-            {tags.map((tag) => (
+            {tags.map((genre) => (
               <GenreAndTagChip
-                key={tag.id}
-                name={tag.name}
-                labels={tag.labels ?? {}}
-                id={tag.id}
-                chipType="seriesTag"
-                context="series"
+                key={genre.id}
+                name={genre.name}
+                labels={genre.labels ?? {}}
+                id={genre.id}
+                chipType="genre"
+                context="static"
               />
             ))}
           </Stack>

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -193,7 +193,7 @@
     "breadcrumb": "Archive / Series / {{name}}",
     "noDescription": "No description available.",
     "noProductions": "There are no productions linked to this series.",
-    "loading": "Loading series...",
+    "loading": "Loading series",
     "notFound": "Series not found.",
     "invalidId": "Invalid series ID.",
     "fetchError": "Could not fetch the series.",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -193,7 +193,7 @@
     "breadcrumb": "Archief / Reeksen / {{name}}",
     "noDescription": "Geen beschrijving beschikbaar.",
     "noProductions": "Er zijn geen producties gekoppeld aan deze reeks.",
-    "loading": "Reeks wordt geladen...",
+    "loading": "Reeks laden",
     "notFound": "Reeks niet gevonden.",
     "invalidId": "Ongeldig reeks-ID.",
     "fetchError": "Kon de reeks niet ophalen.",

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -237,13 +237,21 @@ const SeriesDetailPage = () => {
                   meta={buildProductionMeta(production, i18n.language)}
                   description={buildProductionDescription(production, i18n.language)}
                   onClick={() => navigate(`/productions/${production.id}`)}
-                  tags={production.genres.map((genre) => ({
+                  genres={production.genres.map((genre) => ({
                     id: genre.id,
                     name:
                       genre.display_name ||
                       getLocalizedRecordValue(genre.name, i18n.language) ||
                       t('series.untitled'),
                     labels: genre.name ?? {},
+                  }))}
+                  seriesTags={production.tags.map((tag) => ({
+                    id: tag.id,
+                    name:
+                      tag.display_name ||
+                      getLocalizedRecordValue(tag.name, i18n.language) ||
+                      t('series.untitled'),
+                    labels: tag.name ?? {},
                   }))}
                 />
               </TimelineItem>

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -237,13 +237,13 @@ const SeriesDetailPage = () => {
                   meta={buildProductionMeta(production, i18n.language)}
                   description={buildProductionDescription(production, i18n.language)}
                   onClick={() => navigate(`/productions/${production.id}`)}
-                  tags={production.tags.map((tag) => ({
-                    id: tag.id,
+                  tags={production.genres.map((genre) => ({
+                    id: genre.id,
                     name:
-                      tag.display_name ||
-                      getLocalizedRecordValue(tag.name, i18n.language) ||
+                      genre.display_name ||
+                      getLocalizedRecordValue(genre.name, i18n.language) ||
                       t('series.untitled'),
-                    labels: tag.name ?? {},
+                    labels: genre.name ?? {},
                   }))}
                 />
               </TimelineItem>

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -1,9 +1,3 @@
-/**
- * Displays detailed information about a specific series (tag),
- * including its metadata, statistics and a chronological list
- * of associated productions.
- */
-
 import { useEffect, useMemo, useState } from 'react'
 import { Alert, Box, Container, Divider, Stack, Typography } from '@mui/material'
 import { Navigate, useNavigate, useParams } from 'react-router-dom'
@@ -26,6 +20,8 @@ type SeriesStat = {
   label: string
 }
 
+type SeriesErrorKey = 'series.invalidId' | 'series.fetchError' | null
+
 function getLocalizedRecordValue(
   value: Record<string, string> | null | undefined,
   language: string,
@@ -45,6 +41,7 @@ function extractYearFromProduction(production: Production): string {
   if (production.last_event_end) {
     return new Date(production.last_event_end).getFullYear().toString()
   }
+
   const candidates = [production.display_title, ...Object.values(production.title ?? {})].filter(
     Boolean,
   ) as string[]
@@ -75,11 +72,6 @@ function buildProductionDescription(production: Production, language: string): s
   )
 }
 
-// TODO: use production images in production cards. This is just a placeholder for the moment.
-// function buildProductionImage(_production: Production): string {
-//   return ''
-// }
-
 const SeriesDetailPage = () => {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
@@ -88,13 +80,13 @@ const SeriesDetailPage = () => {
   const [seriesTag, setSeriesTag] = useState<Tag | null>(null)
   const [productions, setProductions] = useState<Production[]>([])
   const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [error, setError] = useState<SeriesErrorKey>(null)
 
   useEffect(() => {
     const numericId = Number(id)
 
     if (!numericId || Number.isNaN(numericId)) {
-      setError(t('series.invalidId'))
+      setError('series.invalidId')
       setIsLoading(false)
       return
     }
@@ -117,14 +109,14 @@ const SeriesDetailPage = () => {
         setSeriesTag(tag)
         setProductions(productionsResponse.results)
       } catch {
-        setError(t('series.fetchError'))
+        setError('series.fetchError')
       } finally {
         setIsLoading(false)
       }
     }
 
     void fetchSeries()
-  }, [id, t])
+  }, [id])
 
   const sortedProductions = useMemo(() => {
     return [...productions].sort((a, b) => {
@@ -201,10 +193,9 @@ const SeriesDetailPage = () => {
             ]}
           />
         </Stack>
+
         <SeriesHeader name={seriesName} description={seriesDescription} />
-
         <SeriesStats stats={stats} />
-
         <Divider />
 
         <Stack spacing={1}>
@@ -254,7 +245,6 @@ const SeriesDetailPage = () => {
                       t('series.untitled'),
                     labels: tag.name ?? {},
                   }))}
-                  // image={buildProductionImage(production)}
                 />
               </TimelineItem>
             ))}


### PR DESCRIPTION
## Description
This PR improves the SeriesDetailPage by addressing two issues:
- Production cards now display the genres associated with each production instead of series tags.
- The page no longer reloads (and shows a loading spinner) when switching languages.

Additionally, related tests have been updated to reflect the use of genres instead of tags, and a new test ensures that genres are correctly rendered.

## Related Issues
- Issue #384 

## Type of Change
- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Documentation
- [x] Other (please specify): UI/UX improvement & test updates

## Testing Instructions
Run frontend tests to verify functionality:

```bash
npm run test -- src/__tests__/components/series_details/
npm run test -- src/__tests__/pages/SeriesDetailPage.test.tsx