### PR TITLE
Refactor: make selected undeline always white

### DIFF
--- a/frontend/src/__tests__/services/MediaFiles.test.ts
+++ b/frontend/src/__tests__/services/MediaFiles.test.ts
@@ -1,8 +1,8 @@
 // src/services/media_files/MediaFiles.test.ts
 
-import { getMediaFile, getMediaFiles } from '../../services/media_files/MediaFiles'
 import { api } from '../../services/Api'
 import { buildListParams } from '../../services/ApiParams'
+import { getMediaFile, getMediaFiles } from '../../services/media_files/MediaFiles'
 
 jest.mock('../../services/Api', () => ({
   api: {

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -40,7 +40,7 @@ type NavbarProps = {
 const Navbar = ({ mode, onToggleMode }: NavbarProps) => {
   const theme = useTheme()
   const commonStyles = createCommonStyles(theme)
-  const navbarStyles = createNavbarStyles(theme)
+  const navbarStyles = createNavbarStyles()
   const { t, i18n } = useTranslation()
   const location = useLocation()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)

--- a/frontend/src/components/series_details/ProductionCard.tsx
+++ b/frontend/src/components/series_details/ProductionCard.tsx
@@ -8,6 +8,7 @@ import DOMPurify from 'dompurify'
 
 import { tokens } from '../../theme/tokens'
 import GenreAndTagChip from '../chips/GenreAndTagChip'
+
 import type { KeyboardEvent, MouseEvent } from 'react'
 
 type ProductionChip = {

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+
 import i18n from '../i18n'
 import { normalizeApiError } from './ApiErrorMapper'
 

--- a/frontend/src/services/media_files/MediaFiles.ts
+++ b/frontend/src/services/media_files/MediaFiles.ts
@@ -1,7 +1,8 @@
-import type { MediaFile, MediaFileListResponse } from '../../types/MediaFiles'
 import { api } from '../Api'
 import { buildListParams } from '../ApiParams'
+
 import type { GetMediaFilesOptions } from './MediaFileOptions'
+import type { MediaFile, MediaFileListResponse } from '../../types/MediaFiles'
 
 /**
  * Retrieve a single media file by its UUID.

--- a/frontend/src/theme/styles.ts
+++ b/frontend/src/theme/styles.ts
@@ -10,10 +10,10 @@ import { tokens } from './tokens'
 
 import type { SxProps, SystemStyleObject, Theme } from '@mui/system'
 
-export const createNavbarStyles = (theme: Theme) => {
+export const createNavbarStyles = () => {
   return {
     activeLink: {
-      borderBottomColor: theme.palette.primary.contrastText,
+      borderBottomColor: tokens.colors.neutral.white,
     } as SystemStyleObject<Theme>,
 
     navLink: {


### PR DESCRIPTION
Just made the selected page underline in the Navbar always white, and some lint fixes.