### PR TITLE
Change function to work with changing query params also

### DIFF
--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -23,7 +23,7 @@ const ScrollToTop = () => {
 
   useLayoutEffect(() => {
     window.scrollTo({ top: 0, left: 0 })
-  }, [location.pathname])
+  }, [location.pathname, location.search])
 
   return null
 }


### PR DESCRIPTION
With pagination, you don’t go to the top of the page. There’s a function for that, but a small adjustment is needed so that it still works when the query parameters change. I think it’s my smallest PR ever ;)