### PR TITLE
[BUG] FE production details page mobile view

### DIFF
--- a/frontend/src/__tests__/components/production/MetaPanel.test.tsx
+++ b/frontend/src/__tests__/components/production/MetaPanel.test.tsx
@@ -82,7 +82,6 @@ describe('MetaPanel component', () => {
     renderMetaPanel(productionStub)
 
     expect(screen.getByText('Titel')).toBeInTheDocument()
-    expect(screen.getByText('Tag')).toBeInTheDocument()
     expect(screen.getByText('Periode')).toBeInTheDocument()
     expect(screen.getByText('Locaties')).toBeInTheDocument()
     expect(screen.getByText('Genre')).toBeInTheDocument()

--- a/frontend/src/__tests__/pages/ProductionDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/ProductionDetailPage.test.tsx
@@ -52,6 +52,23 @@ beforeEach(() => {
 const mockedGetProduction = getProduction as jest.MockedFunction<typeof getProduction>
 const mockedGetBlogs = getBlogs as jest.MockedFunction<typeof getBlogs>
 
+const setMatchMediaMatches = (matches: boolean) => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: jest.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  })
+}
+
 const renderPage = () =>
   render(
     <MemoryRouter>
@@ -67,6 +84,7 @@ describe('ProductionDetailPage', () => {
     mockedGetProduction.mockReset()
     mockedGetBlogs.mockReset()
     languageState.current = 'nl'
+    setMatchMediaMatches(false)
   })
 
   it('shows invalid id error and navigates to home for non-numeric ID', async () => {
@@ -231,7 +249,8 @@ describe('ProductionDetailPage', () => {
 
     await waitFor(() => {
       expect(screen.getAllByText('Productie NL')).toHaveLength(2)
-      expect(screen.getByText('Tagline NL')).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: 'Productie NL' })).toBeInTheDocument()
+      expect(screen.queryByText('Tagline NL')).not.toBeInTheDocument()
       expect(screen.getByText('Teaser NL')).toBeInTheDocument()
       expect(screen.getByText('Omschrijving NL')).toBeInTheDocument()
       expect(screen.getByText('Events')).toBeInTheDocument()
@@ -290,11 +309,46 @@ describe('ProductionDetailPage', () => {
     renderPage()
 
     await waitFor(() => {
-      expect(screen.getByText('Tagline NL')).toBeInTheDocument()
+      expect(screen.queryByText('Tagline NL')).not.toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: 'Productie NL' })).toBeInTheDocument()
       expect(screen.getByText('Events')).toBeInTheDocument()
     })
 
     expect(screen.queryByTestId('related-blogs-mock')).not.toBeInTheDocument()
     expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('renders title at top and hides meta header on mobile', async () => {
+    setMatchMediaMatches(true)
+    mockUseParams.mockReturnValue({ id: '42' })
+
+    mockedGetProduction.mockResolvedValue({
+      id: 42,
+      title: { nl: 'Productie NL' },
+      display_title: 'Display production',
+      artist_name: {},
+      display_artist_name: null,
+      tagline: { nl: 'Tagline NL' },
+      description: { nl: 'Omschrijving NL' },
+      teaser: { nl: 'Teaser NL' },
+      media_gallery: { id: 1, name: 'Primary media', media_items: [] },
+      events: [],
+      genres: [],
+      tags: [],
+      uit_database_type: null,
+      performer_type: 'group',
+      attendance_mode: 'offline',
+      first_event_start: null,
+      last_event_end: null,
+    } as Production)
+    mockedGetBlogs.mockResolvedValue({ count: 0, next: null, previous: null, results: [] })
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Productie NL' })).toBeInTheDocument()
+      expect(screen.queryByText('Tagline NL')).not.toBeInTheDocument()
+      expect(screen.getByText('Teaser NL')).toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/components/production/MetaPanel.tsx
+++ b/frontend/src/components/production/MetaPanel.tsx
@@ -131,6 +131,7 @@ interface MetaPanelProps {
   production: Production
   language?: string
   sx?: SxProps<Theme>
+  showHeader?: boolean
 }
 
 function MetaRow({ label, value }: { label: string; value: string }) {
@@ -188,14 +189,16 @@ function MetaRow({ label, value }: { label: string; value: string }) {
  * - genres/type/etc. are derived and displayed in MetaRow
  * - tags are normalized via formatAllTags and rendered as Tag chips
  */
-export default function MetaPanel({ production, language = 'nl', sx }: MetaPanelProps) {
+export default function MetaPanel({
+  production,
+  language = 'nl',
+  sx,
+  showHeader = true,
+}: MetaPanelProps) {
   const { t } = useTranslation()
 
   const resolvedTitle =
     getLocalizedValue(production.title, language) || production.display_title || ''
-  const resolvedTagline = getLocalizedValue(production.tagline, language)
-  const resolvedArtistName =
-    getLocalizedValue(production.artist_name, language) || production.display_artist_name || ''
 
   const resolvedDateRange = getDateRange(production.events, language)
   const resolvedVenues = getUniqueVenues(production.events, language)
@@ -227,34 +230,24 @@ export default function MetaPanel({ production, language = 'nl', sx }: MetaPanel
         ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
       ]}
     >
-      <Typography
-        component="h1"
-        sx={{
-          fontSize: tokens.typography.sizes['3xl'],
-          fontWeight: tokens.typography.weights.bold,
-          lineHeight: 1.15,
-          mb: 1,
-          letterSpacing: '-0.02em',
-        }}
-      >
-        {resolvedTitle}
-      </Typography>
+      {showHeader && (
+        <>
+          <Typography
+            component="h1"
+            sx={{
+              fontSize: tokens.typography.sizes['3xl'],
+              fontWeight: tokens.typography.weights.bold,
+              lineHeight: 1.15,
+              mb: 1,
+              letterSpacing: '-0.02em',
+            }}
+          >
+            {resolvedTitle}
+          </Typography>
 
-      {(resolvedTagline || resolvedArtistName) && (
-        <Typography
-          component="p"
-          sx={{
-            fontSize: tokens.typography.sizes.sm,
-            color: 'text.secondary',
-            mb: 3,
-            fontStyle: 'italic',
-          }}
-        >
-          {resolvedTagline || resolvedArtistName}
-        </Typography>
+          <Box sx={(theme) => ({ borderTop: `1px solid ${theme.palette.divider}`, mb: 0.5 })} />
+        </>
       )}
-
-      <Box sx={(theme) => ({ borderTop: `1px solid ${theme.palette.divider}`, mb: 0.5 })} />
 
       <Box sx={{ fontFamily: tokens.typography.fontFamily }}>
         {resolvedDateRange && (

--- a/frontend/src/pages/ProductionDetailPage.tsx
+++ b/frontend/src/pages/ProductionDetailPage.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography } from '@mui/material'
+import { Box, Typography, useMediaQuery } from '@mui/material'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useParams, useNavigate } from 'react-router-dom'
@@ -75,6 +75,7 @@ type ProductionDetailContentProps = {
 const ProductionDetailContent = ({ id }: ProductionDetailContentProps) => {
   const navigate = useNavigate()
   const { i18n, t } = useTranslation()
+  const isMobile = useMediaQuery('(max-width:900px)')
   const lang = i18n.language
 
   const [prod, setProd] = useState<Production | null>(null)
@@ -170,6 +171,22 @@ const ProductionDetailContent = ({ id }: ProductionDetailContentProps) => {
               { label: title },
             ]}
           />
+          {isMobile && (
+            <Typography
+              component="h1"
+              sx={{
+                fontSize: tokens.typography.sizes['3xl'],
+                fontWeight: tokens.typography.weights.bold,
+                lineHeight: 1.15,
+                letterSpacing: '-0.02em',
+                color: 'text.primary',
+                mt: 3,
+                mb: 3,
+              }}
+            >
+              {title}
+            </Typography>
+          )}
           <Box
             className="hero-image"
             sx={{
@@ -197,7 +214,12 @@ const ProductionDetailContent = ({ id }: ProductionDetailContentProps) => {
             borderLeft: `1px solid ${theme.palette.divider}`,
           })}
         >
-          <MetaPanel production={production} language={lang} sx={{ borderLeft: 'none' }} />
+          <MetaPanel
+            production={production}
+            language={lang}
+            showHeader={!isMobile}
+            sx={{ borderLeft: 'none' }}
+          />
           <Box
             sx={(theme) => ({
               mt: 3,


### PR DESCRIPTION
# [BUG] FE production details page mobile view

This PR fixes the bug explained in issue #420 

## Description
There is now a check if the viewport is large enough to render the meta panel and the text side by side, in this case the title will be shown above the meta panel. If this is not the case, the meta panel is rendered below the text as usual, but now the title will be rendered above the image.

The other issue with the short description being shown twice (once underneath the image, and once underneath the title) has been fixed by removing the one under the title.

## Related Issues
- closes #420 

## Type of Change
- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please specify): _____________

## Testing Instructions
Run the automated tests with ```npm test```
To test manually go to any productions page and test it with multiple viewports to see if everything works like it should!

