### PR TITLE
[FE][BUG] Grid cards are centered on desktop when only one card is being shown

### DIFF
--- a/frontend/src/__tests__/theme/styles.test.ts
+++ b/frontend/src/__tests__/theme/styles.test.ts
@@ -57,17 +57,17 @@ describe('theme/styles - createCommonStyles', () => {
     expect(cardBaseRecord['&:hover']).toBeDefined()
   })
 
-  it('gridContainer should use an auto-fit CSS grid with card-width tracks centered on each row', () => {
+  it('gridContainer should use an auto-fill CSS grid whose alignment follows the `--grid-align` custom property', () => {
     const commonStyles = createCommonStyles(lightTheme)
     const gridContainerSx = commonStyles.gridContainer as SxProps<Theme>
     const gridContainerRecord = gridContainerSx as Record<string, unknown>
 
     expect(gridContainerRecord.display).toBe('grid')
     expect(gridContainerRecord.gridTemplateColumns).toBe(
-      `repeat(auto-fit, min(${tokens.card.gridCardWidthPx}px, 100%))`,
+      `repeat(auto-fill, min(${tokens.card.gridCardWidthPx}px, 100%))`,
     )
     expect(gridContainerRecord.gap).toBe(tokens.spacing.numericLg)
-    expect(gridContainerRecord.justifyContent).toBe('center')
+    expect(gridContainerRecord.justifyContent).toBe('var(--grid-align, center)')
     expect(gridContainerRecord.alignItems).toBe('stretch')
   })
 

--- a/frontend/src/components/CollectionPageLayout.tsx
+++ b/frontend/src/components/CollectionPageLayout.tsx
@@ -19,21 +19,16 @@ import { useTranslation } from 'react-i18next'
 
 import LoadingSpinner from './LoadingSpinner'
 import Pagination from './Pagination'
-import SearchControlsBar from './searchbar/SearchControlsBar'
 import { tokens } from '../theme/tokens'
+import SearchControlsBar from './searchbar/SearchControlsBar'
 
 import type { SearchSortDirection, SearchSortTarget, SearchViewMode } from './searchbar/types'
 
 /* ------------------------------------------------------------------------- */
-/* Desktop sidebar + grid layout geometry                                    */
+/* Layout geometry                                                           */
 /* ------------------------------------------------------------------------- */
 
-/**
- * Card width (px) used by the `*GridCard` components. The grid container
- * (`createCommonStyles.gridContainer`) tracks at this width, and the content
- * column below snaps to multiples of it so a row of N cards has no leftover
- * space and the whole sidebar+content block can center symmetrically.
- */
+/** Card width (px) shared with `createCommonStyles.gridContainer` tracks. */
 const CARD_WIDTH_PX = tokens.card.gridCardWidthPx
 /** Gap between cards within the grid (theme.spacing(3) = 24px). */
 const CARD_GAP_PX = 24
@@ -49,13 +44,13 @@ const CONTAINER_PADDING_PX = 24 * 2
 const widthForCols = (n: number): number => n * CARD_WIDTH_PX + Math.max(0, n - 1) * CARD_GAP_PX
 
 /**
- * Smallest viewport width at which the sidebar plus N grid cards fit inside
- * the page container. Used to drive the column-count breakpoints below so the
- * step from N to N+1 columns happens exactly when the next card would actually
- * fit on screen rather than at an arbitrary MUI breakpoint.
+ * Smallest viewport width at which N grid cards still fit next to the
+ * (optional) sidebar inside the page container. Drives the column-count
+ * breakpoints below so the step from N to N+1 happens exactly when the next
+ * card would actually fit on screen.
  */
-const viewportThresholdForCols = (n: number): number =>
-  widthForCols(n) + SIDEBAR_WIDTH_PX + SIDEBAR_GAP_PX + CONTAINER_PADDING_PX
+const viewportThresholdForCols = (n: number, withSidebar: boolean): number =>
+  widthForCols(n) + (withSidebar ? SIDEBAR_WIDTH_PX + SIDEBAR_GAP_PX : 0) + CONTAINER_PADDING_PX
 
 export interface CollectionPageLayoutProps {
   isMobile: boolean
@@ -165,18 +160,13 @@ const CollectionPageLayout = ({
   const { t } = useTranslation()
   const theme = useTheme()
   const isEmpty = !isLoading && !errorMessage && !hasResults
-  const shouldRenderSidebar = showSidebar && sidebarContent
+  const shouldRenderSidebar = Boolean(showSidebar && sidebarContent)
   /**
-   * On desktop, when the sidebar is visible alongside a card grid, we snap the
-   * content column to a width that fits an exact number of cards and let the
-   * full sidebar+content block center together via auto margins. This way:
-   *   - cards stay centered within the column,
-   *   - extra space appears symmetrically on both sides of the page rather
-   *     than only between the grid and the right edge,
-   *   - the column width is determined by the viewport (not by the rendered
-   *     content), so the layout doesn't jump when results are empty/loading.
+   * The sidebar lives next to the content column on desktop. On mobile the
+   * same content becomes a full-screen dialog triggered by a filter button,
+   * so at that breakpoint the content column takes over the full width.
    */
-  const isDesktopSidebarGrid = Boolean(shouldRenderSidebar && !isMobile && viewMode === 'grid')
+  const sidebarInline = shouldRenderSidebar && !isMobile
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false)
 
   const mobileSidebarLabel = t('searchbar.filters')
@@ -274,128 +264,99 @@ const CollectionPageLayout = ({
   )
 
   /**
-   * Width of the content column.
+   * Width of the content column (search bar + results + pagination).
    *
-   * For the desktop sidebar+grid case we lock the column to N×card + gaps at
-   * three media-query breakpoints derived from the actual layout geometry
-   * (`viewportThresholdForCols`). Each step happens exactly when the next card
-   * fits next to the sidebar, so we never leave a half-card gap and the whole
-   * block can center via the wrapper's auto margins.
+   * In grid view the column snaps to whole numbers of card tracks so a row
+   * never leaves a half-card gap: 100% below the two-column threshold, then
+   * two and three card widths as more cards fit next to the (optional)
+   * sidebar. At the narrowest step the grid itself centers its lone track
+   * via `commonStyles.gridContainer`.
    *
-   * In every other case (list view, no sidebar, or mobile dialog sidebar) the
-   * column simply fills the remaining flex space.
+   * In list view rows don't need fixed tracks, so the column just scales
+   * gradually and caps at the three-card width - matching the grid's
+   * largest footprint without introducing an intermediate step.
    */
-  const contentColumnSx: SxProps<Theme> = isDesktopSidebarGrid
-    ? {
-        flexShrink: 0,
-        minWidth: 0,
-        // Default column width once we're on desktop (md+): one card.
-        [theme.breakpoints.up('md')]: {
-          width: `${widthForCols(1)}px`,
-        },
-        [`@media (min-width: ${viewportThresholdForCols(2)}px)`]: {
-          width: `${widthForCols(2)}px`,
-        },
-        [`@media (min-width: ${viewportThresholdForCols(3)}px)`]: {
-          width: `${widthForCols(3)}px`,
-        },
-      }
-    : { flex: 1, minWidth: 0 }
-
-  const contentColumn = (
-    <Stack spacing={3} sx={contentColumnSx}>
-      {/* Search, sort, and view controls. */}
-      <SearchControlsBar
-        placeholder={searchPlaceholder}
-        searchValue={searchValue}
-        onSearchChange={onSearchChange}
-        onSearchSubmit={onSearchSubmit}
-        sortTarget={sortTarget}
-        onSortTargetChange={onSortTargetChange}
-        sortDirection={sortDirection}
-        onSortDirectionChange={onSortDirectionChange}
-        sortTargetOptions={sortTargetOptions}
-        extraControls={mobileSidebarButton}
-        viewMode={viewMode}
-        onViewModeChange={onViewModeChange}
-        resultCount={resultCount}
-        showViewModeToggle={!isMobile}
-      />
-
-      {resultsSection}
-
-      {/* Pagination controls. */}
-      <Pagination
-        page={page}
-        pageSize={pageSize}
-        totalItems={totalItems}
-        onPageChange={onPageChange}
-        disabled={isLoading}
-        i18nKeyPrefix={paginationI18nKeyPrefix}
-      />
-    </Stack>
-  )
+  const contentColumnSx: SxProps<Theme> = {
+    flex: 1,
+    minWidth: 0,
+    // When the sidebar is visible we want cards, search bar, and list rows
+    // to hug its right edge rather than re-centering inside the column, so
+    // propagate the intent to `commonStyles.gridContainer` via a CSS
+    // custom property.
+    ...(sidebarInline ? { '--grid-align': 'start' } : null),
+    ...(viewMode === 'grid'
+      ? {
+          maxWidth: '100%',
+          [`@media (min-width: ${viewportThresholdForCols(2, sidebarInline)}px)`]: {
+            maxWidth: `${widthForCols(2)}px`,
+          },
+          [`@media (min-width: ${viewportThresholdForCols(3, sidebarInline)}px)`]: {
+            maxWidth: `${widthForCols(3)}px`,
+          },
+        }
+      : {
+          maxWidth: `${widthForCols(3)}px`,
+        }),
+  }
 
   return (
     <Box sx={{ py: { xs: 3, md: 4 } }}>
       <Container maxWidth="xl">
-        {shouldRenderSidebar && !isMobile ? (
-          isDesktopSidebarGrid ? (
-            // Desktop sidebar + grid: center the whole sidebar+content block
-            // via auto margins. The inner row uses `width: fit-content` so it
-            // shrinks to (sidebar + gap + content column) and the outer Box
-            // distributes any remaining space symmetrically on both sides.
-            <Box sx={{ display: 'flex', justifyContent: 'center', width: '100%' }}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  flexDirection: 'row',
-                  alignItems: 'flex-start',
-                  gap: 3,
-                  width: 'fit-content',
-                  maxWidth: '100%',
-                }}
-              >
-                <Box
-                  sx={{
-                    flexShrink: 0,
-                    width: theme.spacing(SIDEBAR_WIDTH_SPACING),
-                  }}
-                >
-                  {sidebarContent}
-                </Box>
-                {contentColumn}
-              </Box>
+        {/*
+          Single layout for every page: the (optional) sidebar and the
+          content column live in one flex row. When the sidebar is visible
+          we left-align the block so the filter panel hugs the container's
+          left edge; otherwise the content column (and any free space from
+          its stepped cap) center horizontally in the container.
+        */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: sidebarInline ? 'flex-start' : 'center',
+            gap: 3,
+          }}
+        >
+          {sidebarInline ? (
+            <Box sx={{ flexShrink: 0, width: theme.spacing(SIDEBAR_WIDTH_SPACING) }}>
+              {sidebarContent}
             </Box>
-          ) : (
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: { xs: 'column', md: 'row' },
-                gap: 3,
-                alignItems: { xs: 'stretch', md: 'stretch' },
-              }}
-            >
-              <Box
-                sx={{
-                  flexShrink: 0,
-                  width: { xs: '100%', md: theme.spacing(SIDEBAR_WIDTH_SPACING) },
-                  alignSelf: { md: 'flex-start' },
-                }}
-              >
-                {sidebarContent}
-              </Box>
+          ) : null}
 
-              {contentColumn}
-            </Box>
-          )
-        ) : (
-          contentColumn
-        )}
+          <Stack spacing={3} sx={contentColumnSx}>
+            <SearchControlsBar
+              placeholder={searchPlaceholder}
+              searchValue={searchValue}
+              onSearchChange={onSearchChange}
+              onSearchSubmit={onSearchSubmit}
+              sortTarget={sortTarget}
+              onSortTargetChange={onSortTargetChange}
+              sortDirection={sortDirection}
+              onSortDirectionChange={onSortDirectionChange}
+              sortTargetOptions={sortTargetOptions}
+              extraControls={mobileSidebarButton}
+              viewMode={viewMode}
+              onViewModeChange={onViewModeChange}
+              resultCount={resultCount}
+              showViewModeToggle={!isMobile}
+            />
+
+            {resultsSection}
+
+            <Pagination
+              page={page}
+              pageSize={pageSize}
+              totalItems={totalItems}
+              onPageChange={onPageChange}
+              disabled={isLoading}
+              i18nKeyPrefix={paginationI18nKeyPrefix}
+            />
+          </Stack>
+        </Box>
 
         {shouldRenderSidebar && isMobile ? (
           <Dialog
-            open={isMobile && isMobileSidebarOpen}
+            open={isMobileSidebarOpen}
             onClose={() => setIsMobileSidebarOpen(false)}
             fullScreen
             slotProps={{
@@ -410,11 +371,7 @@ const CollectionPageLayout = ({
               },
             }}
           >
-            <DialogContent
-              sx={{
-                p: 0,
-              }}
-            >
+            <DialogContent sx={{ p: 0 }}>
               <Box
                 sx={{
                   '& > .MuiPaper-root': {

--- a/frontend/src/pages/ProductionsPage.tsx
+++ b/frontend/src/pages/ProductionsPage.tsx
@@ -72,7 +72,7 @@ const ProductionsPage = () => {
   const navFloatingAlertMessage = nav.state?.floatingAlert?.message ?? null
   const initialFloatingAlertOpen = Boolean(nav.state?.floatingAlert?.open)
   const initialFloatingAlertMessage = nav.state?.floatingAlert?.message ?? null
-  const isMobile = useMediaQuery(theme.breakpoints.down('lg'))
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
 
   // The useSearchBarUrlState hook is used to synchronize the search bar state with the URL query parameters
   const {

--- a/frontend/src/theme/styles.ts
+++ b/frontend/src/theme/styles.ts
@@ -88,13 +88,26 @@ export const createCommonStyles = (theme: Theme) => {
 
     /**
      * Grid container for wrapping card layouts.
+     *
+     * `auto-fill` preserves empty tracks, so when the parent column is sized
+     * to exactly N card widths a single card naturally lands in the first
+     * track with no bespoke `justify-content` switching required. When the
+     * parent column falls back to 100% width (viewports that can't fit two
+     * card columns), only one track fits and the alignment of that lone card
+     * becomes visible - centered by default, which suits mobile and narrow
+     * sidebar-less layouts.
+     *
+     * Ancestors (e.g. the collection page's content column when a filter
+     * sidebar is visible) can opt into start alignment by setting the
+     * `--grid-align` CSS custom property to `start`, which cascades down
+     * without requiring prop plumbing.
      */
     gridContainer: {
       display: 'grid',
-      gridTemplateColumns: `repeat(auto-fit, min(${tokens.card.gridCardWidthPx}px, 100%))`,
+      gridTemplateColumns: `repeat(auto-fill, min(${tokens.card.gridCardWidthPx}px, 100%))`,
       gap: tokens.spacing.numericLg,
       alignItems: 'stretch',
-      justifyContent: 'center',
+      justifyContent: 'var(--grid-align, center)',
     } as SxProps<Theme>,
 
     /**


### PR DESCRIPTION
## Description
This PR changes the alignment of the grid cards. It will always left align the cards as long there are at least two columns. When there is only one column of cards it centers them, which is needed for mobile view.

## Related Issues
- Closes #427

## Type of Change
- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please specify): _____________

## Testing Instructions
- Make sure that all tests pass
- Go to `/archive`, `/series` and `/blogs` and type in a query that only returns one card and make sure it's left aligned. Gradually change the viewport and see if everything is like it should be.

## Checklist for Reviewers
- [ ] Follows Style Guide
- [ ] Has Documentation (if applicable)
- [ ] Added Unit tests
- [ ] Tested in the relevant environments
