### PR TITLE
[BUG][FE] Make all text fields support HTML safely

### DIFF
--- a/frontend/src/components/BlogGridCard.tsx
+++ b/frontend/src/components/BlogGridCard.tsx
@@ -3,6 +3,7 @@ import { Stack, Typography, useTheme } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import { Link as RouterLink } from 'react-router-dom'
 
+import HtmlText from './HtmlText'
 import ImageWithFallback from './ImageWithFallback'
 import { createCommonStyles } from '../theme/styles'
 import { tokens } from '../theme/tokens'
@@ -69,19 +70,21 @@ const BlogGridCard = ({ blog }: BlogGridCardProps) => {
           >
             {title}
           </Typography>
-          <Typography
+          <HtmlText
+            html={excerpt}
             variant="body2"
-            color="text.secondary"
+            component="div"
+            fallback={t('blogs.home.noExcerpt')}
             sx={{
               display: '-webkit-box',
               WebkitLineClamp: 3,
               WebkitBoxOrient: 'vertical',
               overflow: 'hidden',
               minHeight: 60,
+              fontSize: 'inherit',
+              color: 'text.secondary',
             }}
-          >
-            {excerpt || t('blogs.home.noExcerpt')}
-          </Typography>
+          />
         </Stack>
 
         <Stack

--- a/frontend/src/components/BlogListCard.tsx
+++ b/frontend/src/components/BlogListCard.tsx
@@ -4,6 +4,7 @@ import { Box, Stack, Typography } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import { Link as RouterLink } from 'react-router-dom'
 
+import HtmlText from './HtmlText'
 import ImageWithFallback from './ImageWithFallback'
 import { tokens } from '../theme/tokens'
 import { formatBlogPublishedDate } from '../utils/blogs'
@@ -75,18 +76,20 @@ const BlogListCard = ({ blog }: BlogListCardProps) => {
             {title}
           </Typography>
 
-          <Typography
+          <HtmlText
+            html={excerpt}
             variant="body2"
-            color="text.secondary"
+            component="div"
+            fallback={t('blogs.home.noExcerpt')}
             sx={{
               display: '-webkit-box',
               WebkitLineClamp: 2,
               WebkitBoxOrient: 'vertical',
               overflow: 'hidden',
+              fontSize: 'inherit',
+              color: 'text.secondary',
             }}
-          >
-            {excerpt || t('blogs.home.noExcerpt')}
-          </Typography>
+          />
         </Stack>
 
         {publishedDate ? (

--- a/frontend/src/components/HtmlText.tsx
+++ b/frontend/src/components/HtmlText.tsx
@@ -48,7 +48,7 @@ export default function HtmlText({
   sx,
   ...props
 }: HtmlTextProps) {
-  if (!html) {
+  if (!html?.trim())
     // Render fallback if html is empty
     if (fallback) {
       // If fallback is already a node, return it as-is

--- a/frontend/src/components/HtmlText.tsx
+++ b/frontend/src/components/HtmlText.tsx
@@ -1,0 +1,92 @@
+import { Box, Typography, type TypographyProps } from '@mui/material'
+
+import sanitizeHtml from '../utils/SanitizeHtml'
+
+import type { ReactNode } from 'react'
+
+interface HtmlTextProps extends Omit<TypographyProps, 'children'> {
+  /**
+   * HTML content to render safely.
+   * If empty or falsy, renders the fallback element instead.
+   */
+  html?: string
+  /**
+   * Optional fallback text when html is empty.
+   * Rendered as a Typography with `color="text.secondary"` and `fontStyle="italic"` by default.
+   */
+  fallback?: ReactNode
+  /**
+   * Additional sx styles applied to the rendered Box (or Typography if fallback is shown).
+   */
+  sx?: TypographyProps['sx']
+}
+
+/**
+ * Safely renders HTML content with optional fallback.
+ *
+ * Uses DOMPurify to sanitize HTML before rendering via dangerouslySetInnerHTML.
+ * If html is empty/falsy, renders the fallback element instead.
+ * Automatically styles images to be responsive (max-width 100%, height auto).
+ *
+ * @example
+ * // Render HTML with no fallback
+ * <HtmlText html={description} />
+ *
+ * @example
+ * // Render HTML with fallback text
+ * <HtmlText html={excerpt} fallback={<Typography>No excerpt available</Typography>} />
+ *
+ * @example
+ * // With custom typography props
+ * <HtmlText html={content} variant="body2" component="div" fallback="No content" />
+ */
+export default function HtmlText({
+  html,
+  fallback,
+  component = 'div',
+  variant,
+  sx,
+  ...props
+}: HtmlTextProps) {
+  if (!html) {
+    // Render fallback if html is empty
+    if (fallback) {
+      // If fallback is already a node, return it as-is
+      if (typeof fallback === 'object' && 'type' in fallback) {
+        return fallback
+      }
+      // Otherwise wrap fallback string in Typography
+      return (
+        <Typography
+          variant={variant}
+          component={component}
+          color="text.secondary"
+          sx={{
+            fontStyle: 'italic',
+            ...sx,
+          }}
+          {...props}
+        >
+          {fallback}
+        </Typography>
+      )
+    }
+    return null
+  }
+
+  // Render sanitized HTML
+  return (
+    <Box
+      component={component}
+      sx={{
+        '& img': {
+          maxWidth: '100%',
+          height: 'auto',
+        },
+        ...sx,
+      }}
+      dangerouslySetInnerHTML={{ __html: sanitizeHtml(html) }}
+      {...props}
+    />
+  )
+}

--- a/frontend/src/components/HtmlText.tsx
+++ b/frontend/src/components/HtmlText.tsx
@@ -1,8 +1,7 @@
 import { Box, Typography, type TypographyProps } from '@mui/material'
+import { isValidElement, type ReactNode } from 'react'
 
 import sanitizeHtml from '../utils/SanitizeHtml'
-
-import type { ReactNode,  isValidElement } from 'react'
 
 interface HtmlTextProps extends Omit<TypographyProps, 'children'> {
   /**
@@ -48,13 +47,13 @@ export default function HtmlText({
   sx,
   ...props
 }: HtmlTextProps) {
-  if (!html?.trim())
+  if (!html?.trim()) {
     // Render fallback if html is empty
     if (fallback) {
       // If fallback is already a node, return it as-is
-      if (React.isValidElement(fallback)) {
-   return fallback
-}
+      if (isValidElement(fallback)) {
+        return fallback
+      }
       // Otherwise wrap fallback string in Typography
       return (
         <Typography

--- a/frontend/src/components/HtmlText.tsx
+++ b/frontend/src/components/HtmlText.tsx
@@ -52,9 +52,9 @@ export default function HtmlText({
     // Render fallback if html is empty
     if (fallback) {
       // If fallback is already a node, return it as-is
-      if (typeof fallback === 'object' && 'type' in fallback) {
-        return fallback
-      }
+      if (React.isValidElement(fallback)) {
+   return fallback
+}
       // Otherwise wrap fallback string in Typography
       return (
         <Typography

--- a/frontend/src/components/HtmlText.tsx
+++ b/frontend/src/components/HtmlText.tsx
@@ -2,7 +2,7 @@ import { Box, Typography, type TypographyProps } from '@mui/material'
 
 import sanitizeHtml from '../utils/SanitizeHtml'
 
-import type { ReactNode } from 'react'
+import type { ReactNode,  isValidElement } from 'react'
 
 interface HtmlTextProps extends Omit<TypographyProps, 'children'> {
   /**

--- a/frontend/src/components/production/Description.tsx
+++ b/frontend/src/components/production/Description.tsx
@@ -2,7 +2,7 @@ import { Box, Typography } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 
 import { tokens } from '../../theme/tokens'
-import sanitizeHtml from '../../utils/SanitizeHtml'
+import HtmlText from '../HtmlText'
 
 interface DescriptionProps {
   teaser: string
@@ -24,34 +24,30 @@ export default function Description({ teaser, description }: DescriptionProps) {
       sx={{ color: 'text.primary', background: 'transparent' }}
     >
       {teaser && (
-        <Box
+        <HtmlText
+          html={teaser}
+          variant="body1"
+          component="div"
           sx={{
             fontSize: tokens.typography.sizes.base,
             lineHeight: 1.7,
             color: 'text.secondary',
             fontStyle: 'italic',
             mb: 2.5,
-            '& img': {
-              maxWidth: '100%',
-              height: 'auto',
-            },
           }}
-          dangerouslySetInnerHTML={{ __html: sanitizeHtml(teaser) }}
         />
       )}
 
       {description ? (
-        <Box
+        <HtmlText
+          html={description}
+          variant="body2"
+          component="div"
           sx={{
             fontSize: tokens.typography.sizes.sm,
             lineHeight: 1.8,
             color: 'text.primary',
-            '& img': {
-              maxWidth: '100%',
-              height: 'auto',
-            },
           }}
-          dangerouslySetInnerHTML={{ __html: sanitizeHtml(description) }}
         />
       ) : (
         <Typography

--- a/frontend/src/components/series/SeriesGridCard.tsx
+++ b/frontend/src/components/series/SeriesGridCard.tsx
@@ -6,6 +6,7 @@ import { Link as RouterLink } from 'react-router-dom'
 import { tokens } from '../../theme/tokens'
 import { formatDate } from '../../utils/dateUtils'
 import { getTranslatedRecord } from '../../utils/translations'
+import HtmlText from '../HtmlText'
 import ImageWithFallback from '../ImageWithFallback'
 
 import type { Series } from '../../types/Series'
@@ -85,9 +86,18 @@ const SeriesGridCard = ({ series }: SeriesGridCardProps) => {
           </Typography>
 
           {description ? (
-            <Typography component="p" color="textSecondary" noWrap>
-              {description}
-            </Typography>
+            <HtmlText
+              html={description}
+              variant="body2"
+              component="div"
+              sx={{
+                fontSize: 'inherit',
+                color: 'text.secondary',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            />
           ) : null}
         </Stack>
 

--- a/frontend/src/components/series/SeriesListCard.tsx
+++ b/frontend/src/components/series/SeriesListCard.tsx
@@ -6,6 +6,7 @@ import { Link as RouterLink } from 'react-router-dom'
 
 import { formatDate } from '../../utils/dateUtils'
 import { getTranslatedRecord } from '../../utils/translations'
+import HtmlText from '../HtmlText'
 import ImageWithFallback from '../ImageWithFallback'
 
 import type { Series } from '../../types/Series'
@@ -97,9 +98,18 @@ const SeriesListCard = ({ series }: SeriesListCardProps) => {
           </Typography>
 
           {description ? (
-            <Typography component="p" color="textSecondary" noWrap>
-              {description}
-            </Typography>
+            <HtmlText
+              html={description}
+              variant="body2"
+              component="div"
+              sx={{
+                fontSize: 'inherit',
+                color: 'text.secondary',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            />
           ) : null}
         </Stack>
 

--- a/frontend/src/components/series_details/SeriesHeader.tsx
+++ b/frontend/src/components/series_details/SeriesHeader.tsx
@@ -4,6 +4,8 @@
 
 import { Stack, Typography } from '@mui/material'
 
+import HtmlText from '../HtmlText'
+
 type Props = {
   name: string
   description: string
@@ -15,9 +17,16 @@ const SeriesHeader = ({ name, description }: Props) => {
       <Typography variant="h3" sx={{ fontWeight: 800, overflowWrap: 'break-word' }}>
         {name}
       </Typography>
-      <Typography variant="body1" color="text.secondary" sx={{ overflowWrap: 'break-word' }}>
-        {description}
-      </Typography>
+      <HtmlText
+        html={description}
+        variant="body1"
+        component="div"
+        sx={{
+          color: 'text.secondary',
+          overflowWrap: 'break-word',
+          fontSize: 'inherit',
+        }}
+      />
     </Stack>
   )
 }

--- a/wiki/Frontend.md
+++ b/wiki/Frontend.md
@@ -253,6 +253,31 @@ This focuses on production dependency risk.
 - HTML sanitization uses `dompurify`
 - Secrets should remain in environment variables and never be committed
 
+## HTML Support in Text Sections
+
+All text sections in the frontend (descriptions, excerpts, teaser text, etc.) support **safe HTML rendering** via the `HtmlText` component.
+
+### How It Works
+
+- The `HtmlText` component (`frontend/src/components/HtmlText.tsx`) wraps the `SanitizeHtml` utility to safely render HTML.
+- All HTML is sanitized using **DOMPurify** to prevent XSS attacks.
+- Dangerous attributes (`on*`, `script`, `style`, etc.) are stripped.
+- Images are automatically constrained to responsive sizing (`max-width: 100%`, `height: auto`).
+- If content is empty, an optional fallback message is displayed.
+
+### Components Using HTML Rendering
+
+The following components now support HTML:
+
+| Component | Field | Notes |
+| --- | --- | --- |
+| `BlogGridCard` | `excerpt` | Blog excerpt displayed in grid layout |
+| `BlogListCard` | `excerpt` | Blog excerpt displayed in list layout |
+| `SeriesGridCard` | `description` | Series description in grid layout |
+| `SeriesListCard` | `description` | Series description in list layout |
+| `SeriesHeader` | `description` | Series description on detail page |
+| `Description` (production) | `teaser`, `description` | Production teaser and full description |
+
 ## Troubleshooting
 
 ### Dev Server Port Conflict


### PR DESCRIPTION
# Discription
This PR makes it so all text sections support the html safely.

## Related Issues

- Issue #421 

## Components Using HTML Rendering

The following components now support HTML:

| Component | Field | Notes |
| --- | --- | --- |
| `BlogGridCard` | `excerpt` | Blog excerpt displayed in grid layout |
| `BlogListCard` | `excerpt` | Blog excerpt displayed in list layout |
| `SeriesGridCard` | `description` | Series description in grid layout |
| `SeriesListCard` | `description` | Series description in list layout |
| `SeriesHeader` | `description` | Series description on detail page |
| `Description` (production) | `teaser`, `description` | Production teaser and full description |

## Testing Instructions

Find a production/blog/series that has a html textfield and see if it works

example: http://localhost:5173/series/96

## Checklist for Reviewers
- [x] Follows Style Guide
- [x] Has Documentation (if applicable)
- [ ] Added Unit tests
- [ ] Tested in the relevant environments