### PR TITLE
436 bug selected tab lost when in productiondetailpage

### DIFF
--- a/frontend/src/__tests__/components/Navbar.test.tsx
+++ b/frontend/src/__tests__/components/Navbar.test.tsx
@@ -42,6 +42,11 @@ describe('Navbar', () => {
     expect(screen.getByRole('link', { name: 'Home' })).not.toHaveAttribute('aria-current')
   })
 
+  it('keeps Archive active on production detail routes', () => {
+    renderNavbar('/productions/123')
+    expect(screen.getByRole('link', { name: 'Archief' })).toHaveAttribute('aria-current', 'page')
+  })
+
   it('shows target language and toggles to it when clicking the language button', () => {
     renderNavbar()
     const langButton = screen.getByTestId('language-toggle-inline')

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -59,9 +59,20 @@ const Navbar = ({ mode, onToggleMode }: NavbarProps) => {
     i18n.changeLanguage(language)
   }
 
-  // Home route is exact; others use prefix match for nested pages.
-  const isActive = (to: string) =>
-    to === '/' ? location.pathname === '/' : location.pathname.startsWith(to)
+  // Home route is exact; archive also covers compatibility production URLs.
+  const isActive = (to: string) => {
+    if (to === '/') {
+      return location.pathname === '/'
+    }
+
+    if (to === '/archive') {
+      return (
+        location.pathname.startsWith('/archive') || location.pathname.startsWith('/productions')
+      )
+    }
+
+    return location.pathname.startsWith(to)
+  }
 
   // Close mobile menu and clear route marker.
   const closeMobileMenu = () => {

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -44,9 +44,9 @@ const Router = ({ mode, onToggleMode }: RouterProps) => {
             <Route path="/series/:id" element={<SeriesDetailPage />} />
             <Route path="/blogs" element={<BlogsPage />} />
             <Route path="/blogs/:id" element={<BlogDetailPage />} />
-            <Route path="/media" element={<Navigate to="/archive" replace />} />
+            <Route path="/media" element={<Navigate to="/" replace />} />
             {/* TODO: Remove after media page is implemented */}
-            <Route path="/media/:id" element={<Navigate to="/archive" replace />} />
+            <Route path="/media/:id" element={<Navigate to="/" replace />} />
             {/* TODO: Remove after media page is implemented */}
             <Route path="*" element={<NotFoundPage />} />
           </Routes>


### PR DESCRIPTION
# Description
This PR fixes the bug that the Archive tab is not underlined when in a ProductionsDetailPage.

## Related issue
- #436 

## Type of Change
- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Documentation


## Testing instructions
Open the archive tab, then open a production and see that Archive stays underlined in the Navbar.
Run `npm test`

## Checklist for Reviewers
- [ ] Follows Style Guide
- [ ] Has Documentation (if applicable)
- [ ] Added Unit tests
- [ ] Tested in the relevant environments
