### PR TITLE
[FE][BUG] Clear button in the Filter Panel doesn't visually clear date filter

### DIFF
--- a/frontend/src/components/filter-panel/FilterDatePicker.tsx
+++ b/frontend/src/components/filter-panel/FilterDatePicker.tsx
@@ -1,6 +1,6 @@
 import { DatePicker } from '@mui/x-date-pickers/DatePicker'
 import dayjs, { type Dayjs } from 'dayjs'
-import { useRef, useState, type KeyboardEvent } from 'react'
+import { useLayoutEffect, useRef, useState, type KeyboardEvent } from 'react'
 
 const DATE_PICKER_FORMAT = 'DD/MM/YYYY'
 
@@ -40,17 +40,25 @@ type FilterDatePickerProps = {
 }
 
 /**
- * A controlled date picker that buffers user input as a "draft" and only
- * calls `onChange` when the user confirms (blur, Enter, or calendar close).
- * Externally-driven `value` changes reset the draft automatically.
+ * A controlled date picker that buffers edits as a draft and commits when the user
+ * confirms (blur, Enter, or calendar close). Clearing via the field clear control or
+ * calendar commits immediately. External `value` changes reset the draft.
  */
 const FilterDatePicker = ({ label, value, onChange }: FilterDatePickerProps) => {
   const [field, setField] = useState<DateFieldState>(() => createFieldState(value))
   // Ref keeps the latest field state accessible from stale event-handler closures.
   const fieldRef = useRef(field)
 
-  // If the external value changed (e.g. cleared from outside), ignore local draft.
-  const effectiveField = field.sourceValue === value ? field : createFieldState(value)
+  const [prevExternalValue, setPrevExternalValue] = useState(value)
+  if (value !== prevExternalValue) {
+    setPrevExternalValue(value)
+    const next = createFieldState(value)
+    setField(next)
+  }
+
+  useLayoutEffect(() => {
+    fieldRef.current = field
+  }, [field])
 
   const applyDraft = () => {
     const latest =
@@ -63,7 +71,7 @@ const FilterDatePicker = ({ label, value, onChange }: FilterDatePickerProps) => 
   return (
     <DatePicker
       label={label}
-      value={effectiveField.draft}
+      value={field.draft}
       format={DATE_PICKER_FORMAT}
       disableFuture
       onChange={(newValue, context) => {
@@ -74,9 +82,13 @@ const FilterDatePicker = ({ label, value, onChange }: FilterDatePickerProps) => 
         }
         fieldRef.current = next
         setField(next)
+        if (newValue === null) {
+          onChange('')
+        }
       }}
       onClose={applyDraft}
       slotProps={{
+        field: { clearable: true },
         textField: {
           size: 'small',
           fullWidth: true,


### PR DESCRIPTION
## Description
This PR makes sure that the "Clear all" button in the FilterPanel also clears the visual input field values in the FilterDatePicker.

It also adds an easy way to clear the individual date pickers by adding an "X" on the right side of the input field.

## Related Issues
- Closes #459
- Closes #470

## Type of Change
- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please specify): _____________

## Testing Instructions
1. Go to `/archive`
2. Select a date in a date picker
3. Click the `Clear all` button at the top of the FilterPanel
4. Verify that the input is visually cleared
5. Again, select a date in the date picker
6. Click on the `X` on the right side of the date picker
7. Verify that the input is cleared

Also make sure CI checks still pass

## Checklist for Reviewers
- [ ] Follows Style Guide
- [ ] Has Documentation (if applicable)
- [ ] Added Unit tests
- [ ] Tested in the relevant environments
