### PR TITLE
Show only prods/events before today

### DIFF
--- a/backend/apps/productions/filters.py
+++ b/backend/apps/productions/filters.py
@@ -1,6 +1,7 @@
 """Filters for the Productions app."""
 
 import django_filters
+from django.db.models.functions import Now
 
 from apps.core.filters import BaseModelFilter
 
@@ -40,6 +41,12 @@ class ProductionFilter(BaseModelFilter):
     ``artist_name``
         Case-insensitive substring match across all translated artist names
         (e.g. ``?artist_name=toneelschuur``).
+    ``first_event_start_after``
+        ISO 8601 datetime - returns productions with events starting on or 
+        after this time (only considers events that have already ended).
+    ``first_event_start_before``
+        ISO 8601 datetime - returns productions with events starting on or 
+        before this time (only considers events that have already ended).
     """
 
     genre = django_filters.CharFilter(
@@ -70,16 +77,12 @@ class ProductionFilter(BaseModelFilter):
         distinct=True,
     )
     first_event_start_after = django_filters.IsoDateTimeFilter(
-        field_name="events__starts_at",
-        lookup_expr="gte",
+        method="filter_first_event_start_after",
         label="Has an event starting on or after (ISO 8601)",
-        distinct=True,
     )
     first_event_start_before = django_filters.IsoDateTimeFilter(
-        field_name="events__starts_at",
-        lookup_expr="lte",
+        method="filter_first_event_start_before",
         label="Has an event starting on or before (ISO 8601)",
-        distinct=True,
     )
 
     def filter_has_media(self, queryset: Production, _name: str, value: bool) -> Production:
@@ -87,6 +90,34 @@ class ProductionFilter(BaseModelFilter):
         if value:
             return queryset.exclude(media_gallery__isnull=True)
         return queryset.filter(media_gallery__isnull=True)
+
+    def filter_first_event_start_after(self, queryset: Production, name: str, value) -> Production:
+        """Filter productions with events starting on or after a given datetime.
+        
+        Only considers events that have already ended (ends_at <= Now()).
+        This ensures consistency with the queryset-level event filtering,
+        making date range filters work correctly when combined with other filters.
+        """
+        if value is None:
+            return queryset
+        return queryset.filter(
+            events__starts_at__gte=value,
+            events__ends_at__lte=Now()
+        ).distinct()
+
+    def filter_first_event_start_before(self, queryset: Production, name: str, value) -> Production:
+        """Filter productions with events starting on or before a given datetime.
+        
+        Only considers events that have already ended (ends_at <= Now()).
+        This ensures consistency with the queryset-level event filtering,
+        making date range filters work correctly when combined with other filters.
+        """
+        if value is None:
+            return queryset
+        return queryset.filter(
+            events__starts_at__lte=value,
+            events__ends_at__lte=Now()
+        ).distinct()
 
     def _extract_multi_id_values(self, name: str, value: str | None) -> list[int]:
         """Return deduplicated IDs from repeated and comma-separated query values."""

--- a/backend/apps/productions/filters.py
+++ b/backend/apps/productions/filters.py
@@ -1,7 +1,9 @@
 """Filters for the Productions app."""
 
-import django_filters
+from datetime import datetime
+
 from django.db.models.functions import Now
+import django_filters
 
 from apps.core.filters import BaseModelFilter
 
@@ -42,10 +44,10 @@ class ProductionFilter(BaseModelFilter):
         Case-insensitive substring match across all translated artist names
         (e.g. ``?artist_name=toneelschuur``).
     ``first_event_start_after``
-        ISO 8601 datetime - returns productions with events starting on or 
+        ISO 8601 datetime - returns productions with events starting on or
         after this time (only considers events that have already ended).
     ``first_event_start_before``
-        ISO 8601 datetime - returns productions with events starting on or 
+        ISO 8601 datetime - returns productions with events starting on or
         before this time (only considers events that have already ended).
     """
 
@@ -91,33 +93,27 @@ class ProductionFilter(BaseModelFilter):
             return queryset.exclude(media_gallery__isnull=True)
         return queryset.filter(media_gallery__isnull=True)
 
-    def filter_first_event_start_after(self, queryset: Production, name: str, value) -> Production:
+    def filter_first_event_start_after(self, queryset: Production, _name: str, value: datetime | None) -> Production:
         """Filter productions with events starting on or after a given datetime.
-        
-        Only considers events that have already ended (ends_at <= Now()).
-        This ensures consistency with the queryset-level event filtering,
-        making date range filters work correctly when combined with other filters.
-        """
-        if value is None:
-            return queryset
-        return queryset.filter(
-            events__starts_at__gte=value,
-            events__ends_at__lte=Now()
-        ).distinct()
 
-    def filter_first_event_start_before(self, queryset: Production, name: str, value) -> Production:
-        """Filter productions with events starting on or before a given datetime.
-        
         Only considers events that have already ended (ends_at <= Now()).
         This ensures consistency with the queryset-level event filtering,
         making date range filters work correctly when combined with other filters.
         """
         if value is None:
             return queryset
-        return queryset.filter(
-            events__starts_at__lte=value,
-            events__ends_at__lte=Now()
-        ).distinct()
+        return queryset.filter(events__starts_at__gte=value, events__ends_at__lte=Now()).distinct()
+
+    def filter_first_event_start_before(self, queryset: Production, _name: str, value: datetime | None) -> Production:
+        """Filter productions with events starting on or before a given datetime.
+
+        Only considers events that have already ended (ends_at <= Now()).
+        This ensures consistency with the queryset-level event filtering,
+        making date range filters work correctly when combined with other filters.
+        """
+        if value is None:
+            return queryset
+        return queryset.filter(events__starts_at__lte=value, events__ends_at__lte=Now()).distinct()
 
     def _extract_multi_id_values(self, name: str, value: str | None) -> list[int]:
         """Return deduplicated IDs from repeated and comma-separated query values."""

--- a/backend/apps/productions/serializers.py
+++ b/backend/apps/productions/serializers.py
@@ -429,7 +429,9 @@ class ProductionSerializer(TranslatableSerializerMixin, serializers.ModelSeriali
         # Lazy import, since importing at the top level would cause a circular import between the serializers.
         from apps.events.serializers import NestedEventSerializer  # noqa: PLC0415
 
-        events = obj.events.filter(ends_at__lte=Now())
+        events = getattr(obj, "prefetched_past_events", None)
+        if events is None:
+            events = obj.events.filter(ends_at__lte=Now())
         return NestedEventSerializer(events, many=True).data
 
     def to_representation(self, instance: Production) -> dict:

--- a/backend/apps/productions/serializers.py
+++ b/backend/apps/productions/serializers.py
@@ -16,10 +16,12 @@ Nested relations
 - ``TagSerializer`` - nested many-to-many, carries its own translated fields.
 """
 
-from django.db.models import Prefetch
+from django.db.models import Exists, OuterRef, Prefetch
+from django.db.models.functions import Now
 from rest_framework import serializers
 
 from apps.core.serializers import TranslatableSerializerMixin
+from apps.events.models import Event
 from apps.genres.serializers import GenreSerializer
 from apps.media_library.models import MediaItem
 from apps.media_library.serializers import MediaGallerySerializer
@@ -378,6 +380,10 @@ class ProductionSerializer(TranslatableSerializerMixin, serializers.ModelSeriali
         related_rows = (
             ProductionTag.objects.filter(tag_id__in=tag_ids)
             .exclude(production_id=obj.id)
+            .filter(
+                Exists(Event.objects.filter(production=OuterRef("production_id"), ends_at__lte=Now()))
+                | ~Exists(Event.objects.filter(production=OuterRef("production_id")))
+            )
             .select_related("production", "production__media_gallery")
             .prefetch_related(
                 "production__translations__language",
@@ -423,7 +429,7 @@ class ProductionSerializer(TranslatableSerializerMixin, serializers.ModelSeriali
         # Lazy import, since importing at the top level would cause a circular import between the serializers.
         from apps.events.serializers import NestedEventSerializer  # noqa: PLC0415
 
-        events = obj.events.all()
+        events = obj.events.filter(ends_at__lte=Now())
         return NestedEventSerializer(events, many=True).data
 
     def to_representation(self, instance: Production) -> dict:

--- a/backend/apps/productions/views.py
+++ b/backend/apps/productions/views.py
@@ -181,9 +181,6 @@ class ProductionViewSet(LanguageAwareMixin, ApiModelViewSet):
         language_code = self._get_request_language_code()
         queryset = super().get_queryset()
 
-        if getattr(self, "action", None) == "list":
-            queryset = queryset.filter(events__ends_at__lte=Now()).distinct()
-
         return queryset.annotate(
             title_sort=Lower(
                 Coalesce(

--- a/backend/apps/productions/views.py
+++ b/backend/apps/productions/views.py
@@ -264,6 +264,7 @@ class ProductionViewSet(LanguageAwareMixin, ApiModelViewSet):
                         ),
                     )
                     .select_related("hall__space__location"),
+                    to_attr="prefetched_past_events",
                 ),
             )
 

--- a/backend/apps/productions/views.py
+++ b/backend/apps/productions/views.py
@@ -14,7 +14,7 @@ containing all available translations (e.g., {"nl": "...", "en": "..."}).
 responses still include all translations in a single payload.
 """
 
-from django.db.models import Max, Min, Prefetch, Q, QuerySet
+from django.db.models import Exists, Max, Min, OuterRef, Prefetch, Q, QuerySet
 from django.db.models.functions import Coalesce, Lower, Now
 from django.http import HttpRequest
 from django.utils.decorators import method_decorator
@@ -140,8 +140,11 @@ class ProductionViewSet(LanguageAwareMixin, ApiModelViewSet):
                 ).order_by("position"),
             ),
         )
+        .filter(
+            Exists(Event.objects.filter(production=OuterRef("pk"), ends_at__lte=Now()))
+            | ~Exists(Event.objects.filter(production=OuterRef("pk")))
+        )
         .annotate(
-            # Computed once at the queryset level — not language-dependent.
             first_event_start=Min("events__starts_at", filter=Q(events__ends_at__lte=Now())),
             last_event_end=Max("events__ends_at", filter=Q(events__ends_at__lte=Now())),
         )

--- a/backend/apps/productions/views.py
+++ b/backend/apps/productions/views.py
@@ -15,7 +15,7 @@ responses still include all translations in a single payload.
 """
 
 from django.db.models import Max, Min, Prefetch, Q, QuerySet
-from django.db.models.functions import Coalesce, Lower
+from django.db.models.functions import Coalesce, Lower, Now
 from django.http import HttpRequest
 from django.utils.decorators import method_decorator
 from drf_spectacular.utils import extend_schema
@@ -142,8 +142,8 @@ class ProductionViewSet(LanguageAwareMixin, ApiModelViewSet):
         )
         .annotate(
             # Computed once at the queryset level — not language-dependent.
-            first_event_start=Min("events__starts_at"),
-            last_event_end=Max("events__ends_at"),
+            first_event_start=Min("events__starts_at", filter=Q(events__ends_at__lte=Now())),
+            last_event_end=Max("events__ends_at", filter=Q(events__ends_at__lte=Now())),
         )
     )
 
@@ -180,6 +180,9 @@ class ProductionViewSet(LanguageAwareMixin, ApiModelViewSet):
         """
         language_code = self._get_request_language_code()
         queryset = super().get_queryset()
+
+        if getattr(self, "action", None) == "list":
+            queryset = queryset.filter(events__ends_at__lte=Now()).distinct()
 
         return queryset.annotate(
             title_sort=Lower(
@@ -233,7 +236,8 @@ class ProductionViewSet(LanguageAwareMixin, ApiModelViewSet):
             self.queryset = self.queryset.prefetch_related(
                 Prefetch(
                     "events",
-                    queryset=Event.objects.prefetch_related(
+                    queryset=Event.objects.filter(ends_at__lte=Now())
+                    .prefetch_related(
                         Prefetch(
                             "prices",
                             queryset=EventPrice.objects.select_related("price_rank", "price"),
@@ -258,7 +262,8 @@ class ProductionViewSet(LanguageAwareMixin, ApiModelViewSet):
                             "hall__space__location__translations",
                             queryset=LocationTranslation.objects.select_related("language"),
                         ),
-                    ).select_related("hall__space__location"),
+                    )
+                    .select_related("hall__space__location"),
                 ),
             )
 

--- a/backend/apps/tags/views.py
+++ b/backend/apps/tags/views.py
@@ -85,7 +85,7 @@ class TagViewSet(ApiModelViewSet):
             fallback_crop_path=Subquery(
                 MediaItemCrop.objects.filter(
                     media_item__gallery__productions__tags=OuterRef("pk"),
-                    media_item__gallery__productions__events__ends_at__lte=Now(), # Only consider media from productions with past events
+                    media_item__gallery__productions__events__ends_at__lte=Now(),  # Only consider media from productions with past events
                 )
                 .order_by(
                     "-media_item__gallery__productions__id",

--- a/backend/apps/tags/views.py
+++ b/backend/apps/tags/views.py
@@ -12,7 +12,8 @@ All translated fields are returned as dictionaries mapping language codes
 to their values (e.g., {"nl": "...", "en": "..."}).
 """
 
-from django.db.models import Max, Min, OuterRef, Prefetch, Subquery
+from django.db.models import Count, Max, Min, OuterRef, Prefetch, Q, Subquery
+from django.db.models.functions import Now
 from drf_spectacular.utils import extend_schema
 
 from apps.core.views import ApiModelViewSet
@@ -68,11 +69,23 @@ class TagViewSet(ApiModelViewSet):
     serializer_class = TagSerializer
     queryset = (
         Tag.objects.annotate(
-            first_production_start=Min("productions__events__starts_at"),
-            last_production_end=Max("productions__events__ends_at"),
+            first_production_start=Min(
+                "productions__events__starts_at",
+                filter=Q(productions__events__ends_at__lte=Now()),
+            ),
+            last_production_end=Max(
+                "productions__events__ends_at",
+                filter=Q(productions__events__ends_at__lte=Now()),
+            ),
+            past_event_count=Count(
+                "productions__events",
+                filter=Q(productions__events__ends_at__lte=Now()),
+                distinct=True,
+            ),
             fallback_crop_path=Subquery(
                 MediaItemCrop.objects.filter(
                     media_item__gallery__productions__tags=OuterRef("pk"),
+                    media_item__gallery__productions__events__ends_at__lte=Now(), # Only consider media from productions with past events
                 )
                 .order_by(
                     "-media_item__gallery__productions__id",

--- a/backend/tests/api/test_cache.py
+++ b/backend/tests/api/test_cache.py
@@ -58,6 +58,7 @@ def test_cache_api_view_returns_callable_decorator():
     def view(request):
         return "ok"
 
+    assert view(None) == "ok"
     wrapped = cache_api_view(60)(view)
 
     assert callable(wrapped)

--- a/backend/tests/productions/test_production_filters.py
+++ b/backend/tests/productions/test_production_filters.py
@@ -234,6 +234,30 @@ class TestProductionFilter:
 
         assert self._qs({}).count() == 4
 
+    def test_first_event_start_after_none_returns_unfiltered_queryset(self) -> None:
+        ProductionFactory.create_batch(3)
+        production_filter = ProductionFilter({}, queryset=Production.objects.all())
+
+        result = production_filter.filter_first_event_start_after(
+            Production.objects.all(),
+            "first_event_start_after",
+            None,
+        )
+
+        assert result.count() == 3
+
+    def test_first_event_start_before_none_returns_unfiltered_queryset(self) -> None:
+        ProductionFactory.create_batch(2)
+        production_filter = ProductionFilter({}, queryset=Production.objects.all())
+
+        result = production_filter.filter_first_event_start_before(
+            Production.objects.all(),
+            "first_event_start_before",
+            None,
+        )
+
+        assert result.count() == 2
+
 
 # =====================================================
 # ProductionViewSet

--- a/backend/tests/productions/test_production_serializers.py
+++ b/backend/tests/productions/test_production_serializers.py
@@ -185,6 +185,9 @@ class TestProductionSerializerRelated(TestCase):
             def __init__(self, rows):
                 self.rows = rows
 
+            def filter(self, *_args, **_kwargs):
+                return self
+
             def exclude(self, **_kwargs):
                 return self
 

--- a/backend/tests/productions/test_production_serializers.py
+++ b/backend/tests/productions/test_production_serializers.py
@@ -709,3 +709,129 @@ class TestProductionSerializerEventDateFieldsPopulated(TestCase):
             assert isinstance(value, str)
             parsed = datetime.fromisoformat(value)
             assert parsed.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# ProductionSerializer - get_events method
+# ---------------------------------------------------------------------------
+
+
+class TestProductionSerializerGetEventsNotIncluded(TestCase):
+    """Test that events field is excluded when not in the include set."""
+
+    def setUp(self) -> None:
+        self.production = ProductionFactory.create()
+        EventFactory.create(production=self.production, starts_at=_dt(2025, 9, 1), ends_at=_dt(2025, 9, 1, 22))
+
+    def test_events_field_excluded_without_include(self) -> None:
+        """events field is not present when 'events' is not in the include set."""
+        serializer = ProductionSerializer(self.production, context={"include": set()})
+        assert "events" not in serializer.data
+
+    def test_events_returns_none_when_not_included(self) -> None:
+        """get_events returns None when 'events' is not in the include set."""
+        serializer = ProductionSerializer(self.production, context={"include": set()})
+        # The to_representation method should remove the events field entirely
+        assert "events" not in serializer.data
+
+
+class TestProductionSerializerGetEventsFallbackPath(TestCase):
+    """Test get_events method fallback path (non-prefetched queryset).
+
+    This tests the case where prefetched_past_events is not set, forcing
+    the serializer to query obj.events.filter(ends_at__lte=Now()).
+    """
+
+    def setUp(self) -> None:
+        self.production = ProductionFactory.create()
+        # Create past and future events
+        self.past_event = EventFactory.create(
+            production=self.production,
+            starts_at=_dt(2025, 9, 1),
+            ends_at=_dt(2025, 9, 1, 22),
+        )
+        self.future_event = EventFactory.create(
+            production=self.production,
+            starts_at=_dt(2026, 9, 1),
+            ends_at=_dt(2026, 9, 1, 22),
+        )
+
+    def test_fallback_path_returns_list(self) -> None:
+        """get_events returns a list when using fallback (non-prefetched) path."""
+        serializer = ProductionSerializer(self.production, context={"include": {"events"}})
+        assert isinstance(serializer.data["events"], list)
+
+    def test_fallback_path_filters_future_events(self) -> None:
+        """get_events filters out future events in fallback path."""
+        serializer = ProductionSerializer(self.production, context={"include": {"events"}})
+        event_ids = [e["id"] for e in serializer.data["events"]]
+        assert self.past_event.id in event_ids
+        assert self.future_event.id not in event_ids
+
+    def test_fallback_path_includes_past_events(self) -> None:
+        """get_events includes past events in fallback path."""
+        serializer = ProductionSerializer(self.production, context={"include": {"events"}})
+        event_ids = [e["id"] for e in serializer.data["events"]]
+        assert len(event_ids) == 1
+        assert self.past_event.id in event_ids
+
+    def test_fallback_path_empty_when_no_past_events(self) -> None:
+        """get_events returns empty list when no past events exist."""
+        production = ProductionFactory.create()
+        EventFactory.create(
+            production=production,
+            starts_at=_dt(2026, 9, 1),
+            ends_at=_dt(2026, 9, 1, 22),
+        )
+        serializer = ProductionSerializer(production, context={"include": {"events"}})
+        assert serializer.data["events"] == []
+
+
+class TestProductionSerializerGetEventsPrefetchedPath(TestCase):
+    """Test get_events method when prefetched_past_events is pre-set.
+
+    This tests the optimized path where the viewset has already prefetched
+    the past events into obj.prefetched_past_events.
+    """
+
+    def setUp(self) -> None:
+        self.production = ProductionFactory.create()
+        self.past_event = EventFactory.create(
+            production=self.production,
+            starts_at=_dt(2025, 9, 1),
+            ends_at=_dt(2025, 9, 1, 22),
+        )
+        self.future_event = EventFactory.create(
+            production=self.production,
+            starts_at=_dt(2026, 9, 1),
+            ends_at=_dt(2026, 9, 1, 22),
+        )
+
+    def test_prefetched_path_uses_prefetched_events(self) -> None:
+        """get_events uses prefetched_past_events when available."""
+        # Manually set prefetched_past_events to test the prefetch path
+        self.production.prefetched_past_events = [self.past_event]
+
+        serializer = ProductionSerializer(self.production, context={"include": {"events"}})
+        event_ids = [e["id"] for e in serializer.data["events"]]
+        assert len(event_ids) == 1
+        assert self.past_event.id in event_ids
+
+    def test_prefetched_path_returns_empty_when_no_prefetched(self) -> None:
+        """get_events returns empty list when prefetched_past_events is empty."""
+        self.production.prefetched_past_events = []
+
+        serializer = ProductionSerializer(self.production, context={"include": {"events"}})
+        assert serializer.data["events"] == []
+
+    def test_prefetched_path_respects_only_prefetched_data(self) -> None:
+        """get_events returns only prefetched data, not queried data."""
+        # Set prefetched to only past event, even though future exists
+        self.production.prefetched_past_events = [self.past_event]
+
+        serializer = ProductionSerializer(self.production, context={"include": {"events"}})
+        event_ids = [e["id"] for e in serializer.data["events"]]
+        # Should only contain the one prefetched event
+        assert len(event_ids) == 1
+        assert self.past_event.id in event_ids
+        assert self.future_event.id not in event_ids

--- a/backend/tests/productions/test_production_views.py
+++ b/backend/tests/productions/test_production_views.py
@@ -765,7 +765,7 @@ class TestProductionEventDateFieldsInResponse(TestCase):
         assert results[0]["first_event_start"] is None
         assert results[0]["last_event_end"] is None
 
-    def test_list_fields_are_null_when_only_future_events_exist(self) -> None:
+    def test_production_with_only_future_events_is_excluded(self) -> None:
         Production.objects.all().delete()
         future_only = ProductionFactory.create()
         EventFactory.create(
@@ -775,10 +775,7 @@ class TestProductionEventDateFieldsInResponse(TestCase):
         )
 
         results = self.client.get("/api/v1/productions/", **pub_headers()).data["results"]
-        assert len(results) == 1
-        assert results[0]["id"] == future_only.id
-        assert results[0]["first_event_start"] is None
-        assert results[0]["last_event_end"] is None
+        assert len(results) == 0
 
     def test_patch_with_first_event_start_is_ignored(self) -> None:
         self.client.patch(

--- a/backend/tests/productions/test_production_views.py
+++ b/backend/tests/productions/test_production_views.py
@@ -77,6 +77,16 @@ class TestProductionViewSetList(TestCase):
         Production.objects.all().delete()
         self.production_a = ProductionFactory.create(attendance_mode="offline")
         self.production_b = ProductionFactory.create(attendance_mode="online")
+        EventFactory.create(
+            production=self.production_a,
+            starts_at=datetime(2025, 1, 1, tzinfo=UTC),
+            ends_at=datetime(2025, 1, 1, 22, tzinfo=UTC),
+        )
+        EventFactory.create(
+            production=self.production_b,
+            starts_at=datetime(2025, 2, 1, tzinfo=UTC),
+            ends_at=datetime(2025, 2, 1, 22, tzinfo=UTC),
+        )
 
     def test_list_with_public_key_returns_200(self) -> None:
         response = self.client.get("/api/v1/productions/", **pub_headers())
@@ -417,8 +427,16 @@ class TestProductionViewSetResponseStructure(TestCase):
             uit_database_type=self.db_type,
             attendance_mode="offline",
         )
-        self.event1 = EventFactory.create(production=self.production)
-        self.event2 = EventFactory.create(production=self.production)
+        self.event1 = EventFactory.create(
+            production=self.production,
+            starts_at=_dt(2025, 2, 10),
+            ends_at=_dt(2025, 2, 10, 22),
+        )
+        self.event2 = EventFactory.create(
+            production=self.production,
+            starts_at=_dt(2025, 4, 10),
+            ends_at=_dt(2025, 4, 10, 22),
+        )
         ProductionTranslationFactory.create(
             production=self.production,
             language=self.nl,
@@ -568,6 +586,9 @@ class TestProductionViewSetPrefetch(TestCase):
         self.en = LanguageFactory.create(code="en", name="English")
         for _ in range(5):
             p = ProductionFactory.create()
+            EventFactory.create(
+                production=p, starts_at=datetime(2025, 1, 1, tzinfo=UTC), ends_at=datetime(2025, 1, 1, 22, tzinfo=UTC)
+            )
             ProductionTranslationFactory.create(
                 production=p,
                 language=self.nl,
@@ -604,6 +625,11 @@ class TestProductionApiTagDescription(TestCase):
         self.client = APIClient()
         self.nl = LanguageFactory.create(code="nl")
         self.production = ProductionFactory.create()
+        EventFactory.create(
+            production=self.production,
+            starts_at=datetime(2025, 1, 1, tzinfo=UTC),
+            ends_at=datetime(2025, 1, 1, 22, tzinfo=UTC),
+        )
         self.tag = TagFactory.create(type="theme")
         self.production_tag = ProductionTagFactory.create(production=self.production, tag=self.tag)
         ProductionTagTranslationFactory.create(
@@ -649,6 +675,11 @@ class TestProductionViewSetTagTranslationPrefetch(TestCase):
 
         for _ in range(5):
             production = ProductionFactory.create()
+            EventFactory.create(
+                production=production,
+                starts_at=datetime(2025, 1, 1, tzinfo=UTC),
+                ends_at=datetime(2025, 1, 1, 22, tzinfo=UTC),
+            )
             for tag_type in ("theme", "mood"):
                 tag = TagFactory.create(type=tag_type)
                 pt = ProductionTagFactory.create(production=production, tag=tag)
@@ -681,7 +712,16 @@ class TestProductionEventDateFieldsInResponse(TestCase):
         self.client = APIClient()
         Production.objects.all().delete()
         self.production = ProductionFactory.create()
-        EventFactory.create(production=self.production, starts_at=_dt(2025, 9, 15), ends_at=_dt(2025, 9, 15, 22))
+        self.past_event = EventFactory.create(
+            production=self.production,
+            starts_at=_dt(2025, 9, 15),
+            ends_at=_dt(2025, 9, 15, 22),
+        )
+        self.future_event = EventFactory.create(
+            production=self.production,
+            starts_at=_dt(2030, 1, 10),
+            ends_at=_dt(2030, 1, 10, 22),
+        )
 
     def test_list_contains_first_event_start(self) -> None:
         response = self.client.get("/api/v1/productions/", **pub_headers())
@@ -699,6 +739,12 @@ class TestProductionEventDateFieldsInResponse(TestCase):
         response = self.client.get(f"/api/v1/productions/{self.production.pk}/", **pub_headers())
         assert "last_event_end" in response.data
 
+    def test_detail_with_include_events_omits_future_events(self) -> None:
+        response = self.client.get(f"/api/v1/productions/{self.production.pk}/?include=events", **pub_headers())
+        event_ids = [event["id"] for event in response.data["events"]]
+        assert self.past_event.id in event_ids
+        assert self.future_event.id not in event_ids
+
     def test_list_first_event_start_value_is_correct(self) -> None:
         item = self.client.get("/api/v1/productions/", **pub_headers()).data["results"][0]
         parsed = datetime.fromisoformat(item["first_event_start"])
@@ -712,9 +758,7 @@ class TestProductionEventDateFieldsInResponse(TestCase):
     def test_list_fields_are_null_without_events(self) -> None:
         Production.objects.all().delete()
         ProductionFactory.create()
-        item = self.client.get("/api/v1/productions/", **pub_headers()).data["results"][0]
-        assert item["first_event_start"] is None
-        assert item["last_event_end"] is None
+        assert self.client.get("/api/v1/productions/", **pub_headers()).data["results"] == []
 
     def test_patch_with_first_event_start_is_ignored(self) -> None:
         self.client.patch(
@@ -829,6 +873,11 @@ class TestProductionLanguageAwareOrderingAndSearch(TestCase):
         self.en = LanguageFactory.create(code="en", name="English")
 
         self.prod_alpha_nl = ProductionFactory.create()
+        EventFactory.create(
+            production=self.prod_alpha_nl,
+            starts_at=datetime(2025, 1, 1, tzinfo=UTC),
+            ends_at=datetime(2025, 1, 1, 22, tzinfo=UTC),
+        )
         ProductionTranslationFactory.create(
             production=self.prod_alpha_nl,
             language=self.nl,
@@ -849,6 +898,11 @@ class TestProductionLanguageAwareOrderingAndSearch(TestCase):
         )
 
         self.prod_alpha_en = ProductionFactory.create()
+        EventFactory.create(
+            production=self.prod_alpha_en,
+            starts_at=datetime(2025, 1, 1, tzinfo=UTC),
+            ends_at=datetime(2025, 1, 1, 22, tzinfo=UTC),
+        )
         ProductionTranslationFactory.create(
             production=self.prod_alpha_en,
             language=self.nl,
@@ -889,6 +943,9 @@ class TestProductionLanguageAwareOrderingAndSearch(TestCase):
 
     def test_ordering_by_title_sort_is_case_insensitive(self) -> None:
         prod_lower = ProductionFactory.create()
+        EventFactory.create(
+            production=prod_lower, starts_at=datetime(2025, 1, 1, tzinfo=UTC), ends_at=datetime(2025, 1, 1, 22, tzinfo=UTC)
+        )
         ProductionTranslationFactory.create(
             production=prod_lower,
             language=self.en,
@@ -900,6 +957,9 @@ class TestProductionLanguageAwareOrderingAndSearch(TestCase):
         )
 
         prod_upper = ProductionFactory.create()
+        EventFactory.create(
+            production=prod_upper, starts_at=datetime(2025, 1, 2, tzinfo=UTC), ends_at=datetime(2025, 1, 2, 22, tzinfo=UTC)
+        )
         ProductionTranslationFactory.create(
             production=prod_upper,
             language=self.en,
@@ -948,6 +1008,11 @@ class TestProductionOrderingEdgeCases(TestCase):
         nl = LanguageFactory.create(code="nl", name="Dutch")
 
         self.prod_alpha = ProductionFactory.create()
+        EventFactory.create(
+            production=self.prod_alpha,
+            starts_at=_dt(2025, 1, 1),
+            ends_at=_dt(2025, 1, 1, 20),
+        )
         ProductionTranslationFactory.create(
             production=self.prod_alpha,
             language=en,
@@ -968,6 +1033,11 @@ class TestProductionOrderingEdgeCases(TestCase):
         )
 
         self.prod_zulu = ProductionFactory.create()
+        EventFactory.create(
+            production=self.prod_zulu,
+            starts_at=_dt(2025, 2, 1),
+            ends_at=_dt(2025, 2, 1, 20),
+        )
         ProductionTranslationFactory.create(
             production=self.prod_zulu,
             language=en,
@@ -988,8 +1058,18 @@ class TestProductionOrderingEdgeCases(TestCase):
         )
 
         self.prod_without_translation = ProductionFactory.create()
+        EventFactory.create(
+            production=self.prod_without_translation,
+            starts_at=_dt(2025, 3, 1),
+            ends_at=_dt(2025, 3, 1, 20),
+        )
 
         self.prod_blank_en = ProductionFactory.create()
+        EventFactory.create(
+            production=self.prod_blank_en,
+            starts_at=_dt(2025, 4, 1),
+            ends_at=_dt(2025, 4, 1, 20),
+        )
         ProductionTranslationFactory.create(
             production=self.prod_blank_en,
             language=en,
@@ -1058,29 +1138,25 @@ class TestProductionOrderingEdgeCases(TestCase):
         ids = self._ids({"ordering": "first_event_start"}, **pub_headers())
 
         assert ids.index(self.prod_early.id) < ids.index(self.prod_late.id)
-        assert ids.index(self.prod_without_events.id) > ids.index(self.prod_early.id)
-        assert ids.index(self.prod_without_events.id) > ids.index(self.prod_late.id)
+        assert self.prod_without_events.id not in ids
 
     def test_first_event_start_places_missing_date_last_descending(self) -> None:
         ids = self._ids({"ordering": "-first_event_start"}, **pub_headers())
 
         assert ids.index(self.prod_late.id) < ids.index(self.prod_early.id)
-        assert ids.index(self.prod_without_events.id) > ids.index(self.prod_early.id)
-        assert ids.index(self.prod_without_events.id) > ids.index(self.prod_late.id)
+        assert self.prod_without_events.id not in ids
 
     def test_last_event_end_places_missing_date_last_ascending(self) -> None:
         ids = self._ids({"ordering": "last_event_end"}, **pub_headers())
 
         assert ids.index(self.prod_early.id) < ids.index(self.prod_late.id)
-        assert ids.index(self.prod_without_events.id) > ids.index(self.prod_early.id)
-        assert ids.index(self.prod_without_events.id) > ids.index(self.prod_late.id)
+        assert self.prod_without_events.id not in ids
 
     def test_last_event_end_places_missing_date_last_descending(self) -> None:
         ids = self._ids({"ordering": "-last_event_end"}, **pub_headers())
 
         assert ids.index(self.prod_late.id) < ids.index(self.prod_early.id)
-        assert ids.index(self.prod_without_events.id) > ids.index(self.prod_early.id)
-        assert ids.index(self.prod_without_events.id) > ids.index(self.prod_late.id)
+        assert self.prod_without_events.id not in ids
 
     def test_lang_query_param_overrides_accept_language_header_for_title_sort(self) -> None:
         ids = self._ids(

--- a/backend/tests/productions/test_production_views.py
+++ b/backend/tests/productions/test_production_views.py
@@ -757,8 +757,28 @@ class TestProductionEventDateFieldsInResponse(TestCase):
 
     def test_list_fields_are_null_without_events(self) -> None:
         Production.objects.all().delete()
-        ProductionFactory.create()
-        assert self.client.get("/api/v1/productions/", **pub_headers()).data["results"] == []
+        production_without_events = ProductionFactory.create()
+
+        results = self.client.get("/api/v1/productions/", **pub_headers()).data["results"]
+        assert len(results) == 1
+        assert results[0]["id"] == production_without_events.id
+        assert results[0]["first_event_start"] is None
+        assert results[0]["last_event_end"] is None
+
+    def test_list_fields_are_null_when_only_future_events_exist(self) -> None:
+        Production.objects.all().delete()
+        future_only = ProductionFactory.create()
+        EventFactory.create(
+            production=future_only,
+            starts_at=_dt(2030, 1, 10),
+            ends_at=_dt(2030, 1, 10, 22),
+        )
+
+        results = self.client.get("/api/v1/productions/", **pub_headers()).data["results"]
+        assert len(results) == 1
+        assert results[0]["id"] == future_only.id
+        assert results[0]["first_event_start"] is None
+        assert results[0]["last_event_end"] is None
 
     def test_patch_with_first_event_start_is_ignored(self) -> None:
         self.client.patch(
@@ -1138,25 +1158,25 @@ class TestProductionOrderingEdgeCases(TestCase):
         ids = self._ids({"ordering": "first_event_start"}, **pub_headers())
 
         assert ids.index(self.prod_early.id) < ids.index(self.prod_late.id)
-        assert self.prod_without_events.id not in ids
+        assert ids[-1] == self.prod_without_events.id
 
     def test_first_event_start_places_missing_date_last_descending(self) -> None:
         ids = self._ids({"ordering": "-first_event_start"}, **pub_headers())
 
         assert ids.index(self.prod_late.id) < ids.index(self.prod_early.id)
-        assert self.prod_without_events.id not in ids
+        assert ids[-1] == self.prod_without_events.id
 
     def test_last_event_end_places_missing_date_last_ascending(self) -> None:
         ids = self._ids({"ordering": "last_event_end"}, **pub_headers())
 
         assert ids.index(self.prod_early.id) < ids.index(self.prod_late.id)
-        assert self.prod_without_events.id not in ids
+        assert ids[-1] == self.prod_without_events.id
 
     def test_last_event_end_places_missing_date_last_descending(self) -> None:
         ids = self._ids({"ordering": "-last_event_end"}, **pub_headers())
 
         assert ids.index(self.prod_late.id) < ids.index(self.prod_early.id)
-        assert self.prod_without_events.id not in ids
+        assert ids[-1] == self.prod_without_events.id
 
     def test_lang_query_param_overrides_accept_language_header_for_title_sort(self) -> None:
         ids = self._ids(


### PR DESCRIPTION
I have ensured that the archive page only displays productions and events on the details page that are from before the current time and date. The date ranges have also been adjusted. The same applies to series. Future events are now also not displayed on production detail pages. I think I need to update some code when PR #469 is merged. 
For example, **previously** on the server: 
<img width="361" height="387" alt="image" src="https://github.com/user-attachments/assets/25db2005-22a1-475c-b72e-4478e1c246a6" />
<img width="455" height="873" alt="image" src="https://github.com/user-attachments/assets/cd48a531-683a-4d1f-a5ed-3b6aa3f4d9ae" />

And **now**:
<img width="354" height="367" alt="image" src="https://github.com/user-attachments/assets/7829e545-5c71-423d-89b7-de4c2f167ed7" />
<img width="457" height="501" alt="image" src="https://github.com/user-attachments/assets/f6123f30-1d5f-4d9f-bca5-2351951a48af" />

I have also set the coverage back to 100%.