### PR TITLE
Add include for blogs in backend and frontend

### DIFF
--- a/backend/apps/productions/schemas.py
+++ b/backend/apps/productions/schemas.py
@@ -289,8 +289,9 @@ _PRODUCTION_RETRIEVE = extend_schema(
         "per language; the dictionary is empty when no descriptions have been added. "
         "`include=related` returns productions grouped by tag, where each related tag "
         "is compact and only exposes `id`, `name`, and `display_name`. "
-        "Use `?include=events` to include all related events in the response, or "
-        "`?include=related` to include related productions grouped by tag."
+        "Use `?include=events` to include all related events in the response, "
+        "`?include=related` to include related productions grouped by tag, and "
+        "`?include=blogs` to include linked published blogs."
     ),
     parameters=[
         OpenApiParameter(
@@ -298,11 +299,13 @@ _PRODUCTION_RETRIEVE = extend_schema(
             type=OpenApiTypes.STR,
             location=OpenApiParameter.QUERY,
             required=False,
-            description="Comma-separated list of relations to include. Accepted values: `events`, `related`.",
+            description="Comma-separated list of relations to include. Accepted values: `events`, `related`, `blogs`.",
             examples=[
                 OpenApiExample("No includes", value=""),
                 OpenApiExample("Include events", value="events"),
                 OpenApiExample("Include related", value="related"),
+                OpenApiExample("Include blogs", value="blogs"),
+                OpenApiExample("Include multiple", value="events,related,blogs"),
             ],
         )
     ],

--- a/backend/apps/productions/serializers.py
+++ b/backend/apps/productions/serializers.py
@@ -19,6 +19,7 @@ Nested relations
 from django.db.models import Prefetch
 from rest_framework import serializers
 
+from apps.blogs.models import Blog
 from apps.core.serializers import TranslatableSerializerMixin
 from apps.genres.serializers import GenreSerializer
 from apps.media_library.models import MediaItem
@@ -100,6 +101,70 @@ class RelatedTagSerializer(TagSerializer):
     class Meta(TagSerializer.Meta):
         fields = ["id", "name", "display_name"]
         read_only_fields = fields
+
+
+class ProductionRelatedBlogSerializer(TranslatableSerializerMixin, serializers.ModelSerializer):
+    """Compact blog representation for `ProductionSerializer.blogs`."""
+
+    title = serializers.SerializerMethodField(
+        help_text=(
+            "Dictionary containing all available translations of the blog title, "
+            'e.g. {"en": "I Love Techno 2024", "nl": "I Love Techno 2024"}. '
+            "Read-only."
+        ),
+    )
+
+    excerpt = serializers.SerializerMethodField(
+        help_text=(
+            "Dictionary containing all available translations of the blog excerpt, "
+            'e.g. {"en": "Short summary...", "nl": "Korte samenvatting..."}. '
+            "Read-only."
+        ),
+    )
+
+    display_title = serializers.SerializerMethodField(
+        help_text=(
+            "Human-readable title in the project's base language. "
+            "Falls back to the first available translation when missing."
+        )
+    )
+
+    display_excerpt = serializers.SerializerMethodField(
+        help_text=(
+            "Human-readable excerpt in the project's base language. "
+            "Falls back to the first available translation when missing."
+        )
+    )
+
+    class Meta:
+        model = Blog
+        fields = [
+            "id",
+            "slug",
+            "published_at",
+            "cover_image",
+            "title",
+            "excerpt",
+            "display_title",
+            "display_excerpt",
+        ]
+        read_only_fields = fields
+
+    def get_title(self, obj: Blog) -> dict[str, str] | None:
+        """Return all available title translations as a language-code dictionary."""
+        return self.get_translated_field(obj, "title")
+
+    def get_excerpt(self, obj: Blog) -> dict[str, str] | None:
+        """Return all available excerpt translations as a language-code dictionary."""
+        return self.get_translated_field(obj, "excerpt")
+
+    def get_display_title(self, obj: Blog) -> str | None:
+        """Return the blog title in the project's base language."""
+        return self.get_base_translated_value(obj, "title")
+
+    def get_display_excerpt(self, obj: Blog) -> str | None:
+        """Return the blog excerpt in the project's base language."""
+        return self.get_base_translated_value(obj, "excerpt")
 
 
 class ProductionSerializer(TranslatableSerializerMixin, serializers.ModelSerializer):
@@ -241,6 +306,14 @@ class ProductionSerializer(TranslatableSerializerMixin, serializers.ModelSeriali
         read_only=True,
     )
 
+    blogs = serializers.SerializerMethodField(
+        help_text=(
+            "Published blogs linked to this production. Only present when `include=blogs` "
+            "is passed to the production detail endpoint."
+        ),
+        read_only=True,
+    )
+
     class Meta:
         model = Production
         fields = [
@@ -262,6 +335,7 @@ class ProductionSerializer(TranslatableSerializerMixin, serializers.ModelSeriali
             "genres",
             "events",
             "related",
+            "blogs",
         ]
         read_only_fields = [
             "id",
@@ -279,6 +353,7 @@ class ProductionSerializer(TranslatableSerializerMixin, serializers.ModelSeriali
             "genres",
             "events",
             "related",
+            "blogs",
         ]
         extra_kwargs = {
             "attendance_mode": {
@@ -426,6 +501,15 @@ class ProductionSerializer(TranslatableSerializerMixin, serializers.ModelSeriali
         events = obj.events.all()
         return NestedEventSerializer(events, many=True).data
 
+    def get_blogs(self, obj: Production) -> list | None:
+        """Return published blogs linked to this production when requested."""
+        if "blogs" not in self.context.get("include", set()):
+            return None
+
+        blogs = getattr(obj, "prefetched_related_blogs", None)
+
+        return ProductionRelatedBlogSerializer(blogs, many=True, context=self.context).data
+
     def to_representation(self, instance: Production) -> dict:
         """Override to conditionally include the `events` field based on the serializer context.
 
@@ -436,6 +520,8 @@ class ProductionSerializer(TranslatableSerializerMixin, serializers.ModelSeriali
             rep.pop("events", None)
         if "related" not in self.context.get("include", set()):
             rep.pop("related", None)
+        if "blogs" not in self.context.get("include", set()):
+            rep.pop("blogs", None)
         return rep
 
 

--- a/backend/apps/productions/views.py
+++ b/backend/apps/productions/views.py
@@ -214,7 +214,8 @@ class ProductionViewSet(LanguageAwareMixin, ApiModelViewSet):
     @property
     def includes(self) -> set[str]:
         """Parse the 'include' query parameter into a set of related fields to include."""
-        return set(self.request.query_params.get("include", "").split(","))
+        raw_includes = self.request.query_params.get("include", "")
+        return {value.strip() for value in raw_includes.split(",") if value.strip()}
 
     def get_serializer(self, *args: tuple, **kwargs: dict) -> ProductionSerializer:
         """Pass the 'include' query parameter to the serializer context for dynamic field inclusion."""
@@ -259,6 +260,17 @@ class ProductionViewSet(LanguageAwareMixin, ApiModelViewSet):
                             queryset=LocationTranslation.objects.select_related("language"),
                         ),
                     ).select_related("hall__space__location"),
+                ),
+            )
+
+        if "blogs" in self.includes:
+            self.queryset = self.queryset.prefetch_related(
+                Prefetch(
+                    "blogs",
+                    queryset=Blog.objects.filter(published_at__isnull=False)
+                    .prefetch_related("translations__language")
+                    .order_by("-published_at", "-id"),
+                    to_attr="prefetched_related_blogs",
                 ),
             )
 

--- a/backend/tests/productions/test_production_views.py
+++ b/backend/tests/productions/test_production_views.py
@@ -28,7 +28,7 @@ from apps.core.views import ApiModelViewSet
 from apps.productions.models import Production
 from apps.productions.serializers import ProductionSerializer
 from apps.productions.views import ProductionViewSet
-from tests.factories.blog import BlogFactory
+from tests.factories.blog import BlogFactory, BlogTranslationFactory
 from tests.factories.event import EventFactory
 from tests.factories.language import LanguageFactory
 from tests.factories.production import (
@@ -551,6 +551,64 @@ class TestProductionViewSetResponseStructure(TestCase):
             "display_artist_name",
             "media_gallery",
         }
+
+    def test_retrieve_with_include_blogs_contains_blogs_field(self) -> None:
+        """blogs field is present in response when ?include=blogs is set."""
+        blog = BlogFactory(slug="related-blog", published_at=datetime.now(tz=UTC))
+        BlogTranslationFactory(blog=blog, language=self.nl, title="Gerelateerde blog", body="Body", excerpt="Excerpt")
+        blog.productions.add(self.production)
+
+        response = self.client.get(
+            f"/api/v1/productions/{self.production.id}/?include=blogs",
+            **pub_headers(),
+        )
+
+        assert response.status_code == 200
+        assert "blogs" in response.data
+        assert len(response.data["blogs"]) == 1
+        assert response.data["blogs"][0]["id"] == blog.id
+        assert set(response.data["blogs"][0].keys()) == {
+            "id",
+            "slug",
+            "published_at",
+            "cover_image",
+            "title",
+            "excerpt",
+            "display_title",
+            "display_excerpt",
+        }
+
+    def test_retrieve_without_include_excludes_blogs_field(self) -> None:
+        """blogs field is absent from response when ?include=blogs is not set."""
+        response = self.client.get(f"/api/v1/productions/{self.production.id}/", **pub_headers())
+        assert response.status_code == 200
+        assert "blogs" not in response.data
+
+    def test_retrieve_with_include_blogs_excludes_unpublished_blogs(self) -> None:
+        """Only published blogs are included when ?include=blogs is set."""
+        published_blog = BlogFactory(slug="published-blog", published_at=datetime.now(tz=UTC))
+        BlogTranslationFactory(
+            blog=published_blog,
+            language=self.nl,
+            title="Published blog",
+            body="Body",
+            excerpt="Excerpt",
+        )
+        published_blog.productions.add(self.production)
+
+        draft_blog = BlogFactory(slug="draft-blog", published_at=None)
+        BlogTranslationFactory(blog=draft_blog, language=self.nl, title="Draft blog", body="Body", excerpt="Excerpt")
+        draft_blog.productions.add(self.production)
+
+        response = self.client.get(
+            f"/api/v1/productions/{self.production.id}/?include=blogs",
+            **pub_headers(),
+        )
+
+        assert response.status_code == 200
+        blog_ids = [item["id"] for item in response.data["blogs"]]
+        assert published_blog.id in blog_ids
+        assert draft_blog.id not in blog_ids
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/__tests__/pages/ProductionDetailPage.test.tsx
+++ b/frontend/src/__tests__/pages/ProductionDetailPage.test.tsx
@@ -3,7 +3,6 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 
 import ProductionDetailPage from '../../pages/ProductionDetailPage'
-import { getBlogs } from '../../services/blogs/Blogs'
 import { getProduction } from '../../services/productions/Productions'
 
 import type { Event } from '../../types/Events'
@@ -31,10 +30,6 @@ jest.mock('../../services/productions/Productions', () => ({
   getProduction: jest.fn(),
 }))
 
-jest.mock('../../services/blogs/Blogs', () => ({
-  getBlogs: jest.fn(),
-}))
-
 jest.mock('../../components/production/RelatedProductions', () => ({
   __esModule: true,
   default: () => <div data-testid="related-productions-mock" />,
@@ -50,7 +45,6 @@ beforeEach(() => {
 })
 
 const mockedGetProduction = getProduction as jest.MockedFunction<typeof getProduction>
-const mockedGetBlogs = getBlogs as jest.MockedFunction<typeof getBlogs>
 
 const setMatchMediaMatches = (matches: boolean) => {
   Object.defineProperty(window, 'matchMedia', {
@@ -82,7 +76,6 @@ describe('ProductionDetailPage', () => {
   afterEach(() => {
     jest.clearAllMocks()
     mockedGetProduction.mockReset()
-    mockedGetBlogs.mockReset()
     languageState.current = 'nl'
     setMatchMediaMatches(false)
   })
@@ -227,28 +220,21 @@ describe('ProductionDetailPage', () => {
       attendance_mode: 'offline',
       first_event_start: null,
       last_event_end: null,
-    } as Production
-
-    mockedGetProduction.mockResolvedValue(productionData as Production)
-    mockedGetBlogs.mockResolvedValue({
-      count: 1,
-      next: null,
-      previous: null,
-      results: [
+      blogs: [
         {
           id: 100,
           slug: 'blog',
           published_at: '2025-01-01T10:00:00Z',
           cover_image: null,
           title: { nl: 'Blog' },
-          body: { nl: 'Body' },
           excerpt: { nl: 'Excerpt' },
           display_title: 'Blog',
           display_excerpt: 'Excerpt',
-          productions: [],
         },
       ],
-    })
+    } as Production
+
+    mockedGetProduction.mockResolvedValue(productionData as Production)
 
     renderPage()
 
@@ -263,14 +249,13 @@ describe('ProductionDetailPage', () => {
       expect(screen.getByTestId('related-blogs-mock')).toBeInTheDocument()
     })
 
-    expect(mockedGetBlogs).toHaveBeenCalledWith({ filters: { production: 42, published: true } })
+    expect(mockedGetProduction).toHaveBeenCalledWith(42, ['events', 'related', 'blogs'])
     expect(mockNavigate).not.toHaveBeenCalled()
   })
 
   it('shows load failed if getProduction throws and navigates to home', async () => {
     mockUseParams.mockReturnValue({ id: '42' })
     mockedGetProduction.mockRejectedValue(new Error('network error'))
-    mockedGetBlogs.mockResolvedValue({ count: 0, next: null, previous: null, results: [] })
 
     renderPage()
 
@@ -287,7 +272,7 @@ describe('ProductionDetailPage', () => {
     })
   })
 
-  it('keeps rendering production details when related blog loading fails', async () => {
+  it('keeps rendering production details when no related blogs are returned', async () => {
     mockUseParams.mockReturnValue({ id: '42' })
 
     mockedGetProduction.mockResolvedValue({
@@ -308,8 +293,8 @@ describe('ProductionDetailPage', () => {
       attendance_mode: 'offline',
       first_event_start: null,
       last_event_end: null,
+      blogs: [],
     } as Production)
-    mockedGetBlogs.mockRejectedValue(new Error('blog error'))
 
     renderPage()
 
@@ -345,8 +330,8 @@ describe('ProductionDetailPage', () => {
       attendance_mode: 'offline',
       first_event_start: null,
       last_event_end: null,
+      blogs: [],
     } as Production)
-    mockedGetBlogs.mockResolvedValue({ count: 0, next: null, previous: null, results: [] })
 
     renderPage()
 

--- a/frontend/src/__tests__/services/Productions.test.ts
+++ b/frontend/src/__tests__/services/Productions.test.ts
@@ -124,6 +124,16 @@ describe('productions service', () => {
       expect(mockedGet).toHaveBeenCalledWith('/productions/42/', { params: { include: 'events' } })
       expect(result).toEqual(productionWithEvents)
     })
+
+    it('joins multiple include values in one query parameter', async () => {
+      mockedGet.mockResolvedValue({ data: mockProduction })
+
+      await getProduction(42, ['events', 'related', 'blogs'])
+
+      expect(mockedGet).toHaveBeenCalledWith('/productions/42/', {
+        params: { include: 'events,related,blogs' },
+      })
+    })
   })
 
   describe('getProductions', () => {

--- a/frontend/src/components/BlogGridCard.tsx
+++ b/frontend/src/components/BlogGridCard.tsx
@@ -11,10 +11,10 @@ import { formatBlogPublishedDate } from '../utils/blogs'
 import { resolveCurrentLanguage, toLocalizedPath } from '../utils/localizedRoutes'
 import { getTranslatedRecord } from '../utils/translations'
 
-import type { Blog } from '../types/Blogs'
+import type { BlogCardData } from '../types/Blogs'
 
 export interface BlogGridCardProps {
-  blog: Blog
+  blog: BlogCardData
 }
 
 const BlogGridCard = ({ blog }: BlogGridCardProps) => {

--- a/frontend/src/components/production/RelatedBlogs.tsx
+++ b/frontend/src/components/production/RelatedBlogs.tsx
@@ -5,10 +5,10 @@ import { tokens } from '../../theme/tokens'
 import BlogGridCard from '../BlogGridCard'
 import Carousel from '../carousel/Carousel'
 
-import type { Blog } from '../../types/Blogs'
+import type { BlogCardData } from '../../types/Blogs'
 
 interface RelatedBlogsProps {
-  blogs: Blog[]
+  blogs: BlogCardData[]
 }
 
 function RelatedBlogs({ blogs }: RelatedBlogsProps) {

--- a/frontend/src/pages/ProductionDetailPage.tsx
+++ b/frontend/src/pages/ProductionDetailPage.tsx
@@ -12,13 +12,11 @@ import MediaList from '../components/production/MediaList'
 import MetaPanel from '../components/production/MetaPanel'
 import RelatedBlogs from '../components/production/RelatedBlogs'
 import RelatedProductions from '../components/production/RelatedProductions'
-import { getBlogs } from '../services/blogs/Blogs'
 import { getProduction } from '../services/productions/Productions'
 import { tokens } from '../theme/tokens'
 import { getLocalizedValue } from '../utils/localization'
 import { resolveCurrentLanguage, toLocalizedPath } from '../utils/localizedRoutes'
 
-import type { Blog } from '../types/Blogs'
 import type { Production } from '../types/Productions'
 
 /**
@@ -87,7 +85,6 @@ const ProductionDetailContent = ({ id }: ProductionDetailContentProps) => {
   const homePath = toLocalizedPath('/', currentLanguage)
 
   const [prod, setProd] = useState<Production | null>(null)
-  const [relatedBlogs, setRelatedBlogs] = useState<Blog[]>([])
   const [loading, setLoading] = useState<boolean>(true)
 
   // useEffect to fetch the production given the id in the URL.
@@ -103,18 +100,8 @@ const ProductionDetailContent = ({ id }: ProductionDetailContentProps) => {
 
     const fetchProduction = async () => {
       try {
-        const data = await getProduction(parsed, ['events', 'related'])
+        const data = await getProduction(parsed, ['events', 'related', 'blogs'])
         setProd(data)
-
-        try {
-          const blogData = await getBlogs({
-            filters: { production: data.id, published: true },
-          })
-          setRelatedBlogs(blogData.results)
-        } catch {
-          // Keep the detail page usable even if related blog loading fails.
-          setRelatedBlogs([])
-        }
       } catch {
         const errMsg = t('productions.detail.error.loadFailed', 'Could not load production')
         navigate(homePath, {
@@ -154,6 +141,7 @@ const ProductionDetailContent = ({ id }: ProductionDetailContentProps) => {
   const heroImage = getProductionHeroImageUrl(production)
   const events = production.events ?? []
   const relatedProductions = production.related ?? []
+  const relatedBlogs = production.blogs ?? []
 
   return (
     <Box

--- a/frontend/src/types/Blogs.ts
+++ b/frontend/src/types/Blogs.ts
@@ -1,18 +1,24 @@
 import type { Production } from './Productions'
 
 /**
- * Blog object returned by the backend `/blogs/` endpoints.
+ * Minimal blog fields required for blog cards and related blog sections.
  */
-export interface Blog {
+export interface BlogCardData {
   id: number
   slug: string
   published_at: string | null
   cover_image: string | null
   title: Record<string, string>
-  body: Record<string, string>
   excerpt: Record<string, string>
   display_title: string
   display_excerpt: string
+}
+
+/**
+ * Blog object returned by the backend `/blogs/` endpoints.
+ */
+export interface Blog extends BlogCardData {
+  body: Record<string, string>
   productions: Production[]
 }
 

--- a/frontend/src/types/Productions.ts
+++ b/frontend/src/types/Productions.ts
@@ -1,3 +1,4 @@
+import type { BlogCardData } from './Blogs'
 import type { Event } from './Events'
 import type { Genre } from './Genres'
 import type { MediaGallery } from './Media'
@@ -62,6 +63,7 @@ export interface Production {
   genres: Genre[]
   events?: Event[]
   related?: ProductionRelated[]
+  blogs?: BlogCardData[]
 }
 
 /**

--- a/wiki/API Overview.md
+++ b/wiki/API Overview.md
@@ -199,6 +199,21 @@ This returns only productions that have both genres `2` and `9` and both tags `5
 
 ---
 
+## Production Detail Includes
+
+The production detail endpoint supports optional includes to embed related data in a single request:
+
+- `GET /api/v1/productions/:id/?include=events`
+- `GET /api/v1/productions/:id/?include=related`
+- `GET /api/v1/productions/:id/?include=blogs`
+- Includes can be combined: `?include=events,related,blogs`
+
+Behavior:
+
+- When an include is present, the corresponding field is embedded in the detail response.
+- When an include is absent, the field is omitted from the payload.
+- `include=blogs` returns only published blogs linked to the production.
+
 ---
 
 ## Landing Stats Endpoint


### PR DESCRIPTION
I’ve added that `included` so that you only send one request, rather than separate ones for each blog. See the issue description. The issue with the one missing line for 100% coverage is being resolved in another pull request (#473 ) of mine.

You can check this by going to `Inspect` on the page and then selecting `Network`. (on details of a production)