### PR TITLE
Update Django to 6.0.5

### DIFF
--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==6.0.4
+Django==6.0.5
 djangorestframework==3.17.1
 drf-spectacular==0.29.0
 django-filter==25.2


### PR DESCRIPTION
It fixes this errors.
<img width="1301" height="343" alt="image" src="https://github.com/user-attachments/assets/005d2bfe-bd3c-42f2-b8a2-c09d88055b5c" />

You can install it with ```pip install -r backend/requirements/development.txt```