### PR TITLE
[FE][FEATURE] Make genres in the filterpanel scrollable

### DIFF
--- a/frontend/src/__tests__/components/ChipFilterSection.test.tsx
+++ b/frontend/src/__tests__/components/ChipFilterSection.test.tsx
@@ -1,0 +1,264 @@
+import { ThemeProvider, createTheme } from '@mui/material/styles'
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { I18nextProvider } from 'react-i18next'
+
+import ChipFilterSection, { type ChipOption } from '../../components/filter-panel/ChipFilterSection'
+import i18n from '../../i18n'
+
+jest.mock('../../components/chips/GenreAndTagChip', () => ({
+  __esModule: true,
+  default: ({
+    id,
+    name,
+    chipType,
+    selected,
+    onToggle,
+  }: {
+    id: number
+    name: string
+    chipType: 'genre' | 'seriesTag'
+    selected?: boolean
+    onToggle?: () => void
+  }) => (
+    <button
+      type="button"
+      data-testid={`chip-${chipType}-${String(id)}`}
+      data-selected={selected ? 'true' : 'false'}
+      onClick={onToggle}
+    >
+      {name}
+    </button>
+  ),
+}))
+
+const genre = (id: number, name: string): ChipOption => ({
+  id,
+  name,
+  labels: { nl: name },
+  chipType: 'genre',
+})
+
+const seriesTag = (id: number, name: string): ChipOption => ({
+  id,
+  name,
+  labels: { nl: name },
+  chipType: 'seriesTag',
+})
+
+type RenderSectionProps = {
+  options: ChipOption[]
+  selectedIds?: number[]
+  emptyLabel?: string
+  onToggle?: (id: number) => void
+}
+
+const renderSection = (props: RenderSectionProps) => {
+  const onToggle = props.onToggle ?? jest.fn()
+  const view = render(
+    <I18nextProvider i18n={i18n}>
+      <ThemeProvider theme={createTheme()}>
+        <ChipFilterSection
+          options={props.options}
+          selectedIds={props.selectedIds ?? []}
+          emptyLabel={props.emptyLabel ?? 'empty'}
+          onToggle={onToggle}
+        />
+      </ThemeProvider>
+    </I18nextProvider>,
+  )
+  return { ...view, onToggle }
+}
+
+describe('ChipFilterSection', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    await i18n.changeLanguage('nl')
+  })
+
+  it('does not show search or a scroll region when there are five or fewer options', () => {
+    renderSection({
+      options: [genre(1, 'A'), genre(2, 'B'), genre(3, 'C'), genre(4, 'D'), genre(5, 'E')],
+    })
+
+    expect(
+      screen.queryByPlaceholderText(i18n.t('productions.home.filters.searchGenres')),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('region', { name: i18n.t('productions.home.filters.scrollHint') }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(i18n.t('productions.home.filters.scrollHint')),
+    ).not.toBeInTheDocument()
+  })
+
+  it('sorts selected options first and places overflow options in a scrollable region', () => {
+    renderSection({
+      options: [
+        genre(6, 'Alpha'),
+        genre(1, 'Delta'),
+        genre(2, 'Charlie'),
+        genre(3, 'Echo'),
+        genre(4, 'Bravo'),
+        genre(5, 'Foxtrot'),
+      ],
+      selectedIds: [6],
+    })
+
+    expect(screen.getAllByTestId(/chip-genre-/).map((chip) => chip.textContent)).toEqual([
+      'Alpha',
+      'Bravo',
+      'Charlie',
+      'Delta',
+      'Echo',
+      'Foxtrot',
+    ])
+    expect(screen.getByTestId('chip-genre-6')).toHaveAttribute('data-selected', 'true')
+    expect(
+      screen.getByRole('region', { name: i18n.t('productions.home.filters.scrollHint') }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText(i18n.t('productions.home.filters.scrollHint')),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: i18n.t('productions.home.filters.scrollHint') }),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^(Meer|More)$/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^(Minder|Less)$/ })).not.toBeInTheDocument()
+  })
+
+  it('shows the genre search placeholder when there is overflow and options are genres', () => {
+    renderSection({
+      options: [
+        genre(1, 'Alpha'),
+        genre(2, 'Bravo'),
+        genre(3, 'Charlie'),
+        genre(4, 'Delta'),
+        genre(5, 'Echo'),
+        genre(6, 'Foxtrot'),
+      ],
+    })
+
+    expect(
+      screen.getByPlaceholderText(i18n.t('productions.home.filters.searchGenres')),
+    ).toBeInTheDocument()
+  })
+
+  it('shows the tag search placeholder when there is overflow and options are series tags', () => {
+    renderSection({
+      options: [
+        seriesTag(1, 'Alpha'),
+        seriesTag(2, 'Bravo'),
+        seriesTag(3, 'Charlie'),
+        seriesTag(4, 'Delta'),
+        seriesTag(5, 'Echo'),
+        seriesTag(6, 'Foxtrot'),
+      ],
+    })
+
+    expect(
+      screen.getByPlaceholderText(i18n.t('productions.home.filters.searchTags')),
+    ).toBeInTheDocument()
+  })
+
+  it('filters genre chips by a case-insensitive substring of the name', () => {
+    renderSection({
+      options: [
+        genre(1, 'Alpha'),
+        genre(2, 'Bravo'),
+        genre(3, 'Charlie'),
+        genre(4, 'Delta'),
+        genre(5, 'Echo'),
+        genre(6, 'Foxtrot'),
+      ],
+    })
+
+    const search = screen.getByPlaceholderText(i18n.t('productions.home.filters.searchGenres'))
+    fireEvent.change(search, { target: { value: 'BRAV' } })
+
+    expect(screen.getByTestId('chip-genre-2')).toHaveTextContent('Bravo')
+    expect(screen.queryByTestId('chip-genre-1')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('chip-genre-3')).not.toBeInTheDocument()
+  })
+
+  it('trims leading and trailing whitespace from the search query', () => {
+    renderSection({
+      options: [
+        genre(1, 'Alpha'),
+        genre(2, 'Bravo'),
+        genre(3, 'Charlie'),
+        genre(4, 'Delta'),
+        genre(5, 'Echo'),
+        genre(6, 'Foxtrot'),
+      ],
+    })
+
+    const search = screen.getByPlaceholderText(i18n.t('productions.home.filters.searchGenres'))
+    fireEvent.change(search, { target: { value: '  echo  ' } })
+
+    expect(screen.getByTestId('chip-genre-5')).toHaveTextContent('Echo')
+    expect(screen.queryByTestId('chip-genre-1')).not.toBeInTheDocument()
+  })
+
+  it('shows the empty label when the search matches no options', () => {
+    const emptyLabel = 'Geen resultaten'
+    renderSection({
+      options: [
+        genre(1, 'Alpha'),
+        genre(2, 'Bravo'),
+        genre(3, 'Charlie'),
+        genre(4, 'Delta'),
+        genre(5, 'Echo'),
+        genre(6, 'Foxtrot'),
+      ],
+      emptyLabel,
+    })
+
+    const search = screen.getByPlaceholderText(i18n.t('productions.home.filters.searchGenres'))
+    fireEvent.change(search, { target: { value: 'zzz' } })
+
+    expect(screen.getByText(emptyLabel)).toBeInTheDocument()
+    expect(screen.queryByTestId(/chip-genre-/)).not.toBeInTheDocument()
+  })
+
+  it('clears the filter and shows all chips again when the search is cleared', () => {
+    renderSection({
+      options: [
+        genre(1, 'Alpha'),
+        genre(2, 'Bravo'),
+        genre(3, 'Charlie'),
+        genre(4, 'Delta'),
+        genre(5, 'Echo'),
+        genre(6, 'Foxtrot'),
+      ],
+    })
+
+    const search = screen.getByPlaceholderText(i18n.t('productions.home.filters.searchGenres'))
+    fireEvent.change(search, { target: { value: 'bravo' } })
+    expect(screen.queryByTestId('chip-genre-1')).not.toBeInTheDocument()
+
+    fireEvent.change(search, { target: { value: '' } })
+
+    expect(screen.getByTestId('chip-genre-1')).toBeInTheDocument()
+    expect(screen.getByTestId('chip-genre-6')).toBeInTheDocument()
+  })
+
+  it('filters tag chips the same way as genres', () => {
+    renderSection({
+      options: [
+        seriesTag(1, 'Premiere'),
+        seriesTag(2, 'Festival'),
+        seriesTag(3, 'Tour'),
+        seriesTag(4, 'Kids'),
+        seriesTag(5, 'Dance'),
+        seriesTag(6, 'Music'),
+      ],
+    })
+
+    const search = screen.getByPlaceholderText(i18n.t('productions.home.filters.searchTags'))
+    fireEvent.change(search, { target: { value: 'fest' } })
+
+    expect(screen.getByTestId('chip-seriesTag-2')).toHaveTextContent('Festival')
+    expect(screen.queryByTestId('chip-seriesTag-1')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/__tests__/components/FilterPanel.test.tsx
+++ b/frontend/src/__tests__/components/FilterPanel.test.tsx
@@ -1,6 +1,3 @@
-/// <reference types="jest" />
-/// <reference types="@testing-library/jest-dom" />
-
 import { ThemeProvider, createTheme } from '@mui/material/styles'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import React, { type ReactNode } from 'react'
@@ -303,60 +300,6 @@ describe('FilterPanel', () => {
     expect(screen.getByTestId('chip-genre-5')).toHaveTextContent('Display Only Genre')
     expect(screen.getByTestId('chip-seriesTag-11')).toHaveTextContent('Display Tag')
     expect(screen.getByTestId('chip-seriesTag-12')).toHaveTextContent('Partial Tag')
-  })
-
-  it('sorts selected genres first and places overflow options in a scrollable region', () => {
-    renderPanel({
-      genres: [
-        buildGenre({ id: 6, name: { nl: 'Alpha' } }),
-        buildGenre({ id: 1, name: { nl: 'Delta' } }),
-        buildGenre({ id: 2, name: { nl: 'Charlie' } }),
-        buildGenre({ id: 3, name: { nl: 'Echo' } }),
-        buildGenre({ id: 4, name: { nl: 'Bravo' } }),
-        buildGenre({ id: 5, name: { nl: 'Foxtrot' } }),
-      ],
-      selectedGenreIds: [6],
-    })
-
-    expect(screen.getAllByTestId(/chip-genre-/).map((chip) => chip.textContent)).toEqual([
-      'Alpha',
-      'Bravo',
-      'Charlie',
-      'Delta',
-      'Echo',
-      'Foxtrot',
-    ])
-    expect(screen.getByTestId('chip-genre-6')).toHaveAttribute('data-selected', 'true')
-    expect(
-      screen.getByRole('region', { name: i18n.t('productions.home.filters.scrollHint') }),
-    ).toBeInTheDocument()
-    expect(
-      screen.queryByText(i18n.t('productions.home.filters.scrollHint')),
-    ).not.toBeInTheDocument()
-    expect(
-      screen.queryByRole('button', { name: i18n.t('productions.home.filters.scrollHint') }),
-    ).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /^(Meer|More)$/ })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /^(Minder|Less)$/ })).not.toBeInTheDocument()
-  })
-
-  it('does not create a scroll region when five or fewer chip options are available', () => {
-    renderPanel({
-      genres: [
-        buildGenre({ id: 1, name: { nl: 'Alpha' } }),
-        buildGenre({ id: 2, name: { nl: 'Bravo' } }),
-        buildGenre({ id: 3, name: { nl: 'Charlie' } }),
-        buildGenre({ id: 4, name: { nl: 'Delta' } }),
-        buildGenre({ id: 5, name: { nl: 'Echo' } }),
-      ],
-    })
-
-    expect(
-      screen.queryByRole('region', { name: i18n.t('productions.home.filters.scrollHint') }),
-    ).not.toBeInTheDocument()
-    expect(
-      screen.queryByText(i18n.t('productions.home.filters.scrollHint')),
-    ).not.toBeInTheDocument()
   })
 
   it('adds and removes genre and tag ids when chips are toggled', () => {

--- a/frontend/src/__tests__/components/FilterPanel.test.tsx
+++ b/frontend/src/__tests__/components/FilterPanel.test.tsx
@@ -305,7 +305,7 @@ describe('FilterPanel', () => {
     expect(screen.getByTestId('chip-seriesTag-12')).toHaveTextContent('Partial Tag')
   })
 
-  it('sorts selected genres first and toggles overflow visibility with show more and show less', () => {
+  it('sorts selected genres first and places overflow options in a scrollable region', () => {
     renderPanel({
       genres: [
         buildGenre({ id: 6, name: { nl: 'Alpha' } }),
@@ -324,37 +324,39 @@ describe('FilterPanel', () => {
       'Charlie',
       'Delta',
       'Echo',
-    ])
-    expect(screen.getByTestId('chip-genre-6')).toHaveAttribute('data-selected', 'true')
-    expect(screen.queryByTestId('chip-genre-5')).not.toBeInTheDocument()
-
-    fireEvent.click(
-      screen.getByRole('button', { name: i18n.t('productions.home.filters.showMore') }),
-    )
-
-    expect(screen.getAllByTestId(/chip-genre-/).map((chip) => chip.textContent)).toEqual([
-      'Alpha',
-      'Bravo',
-      'Charlie',
-      'Delta',
-      'Echo',
       'Foxtrot',
     ])
+    expect(screen.getByTestId('chip-genre-6')).toHaveAttribute('data-selected', 'true')
     expect(
-      screen.getByRole('button', { name: i18n.t('productions.home.filters.showLess') }),
+      screen.getByRole('region', { name: i18n.t('productions.home.filters.scrollHint') }),
     ).toBeInTheDocument()
+    expect(
+      screen.queryByText(i18n.t('productions.home.filters.scrollHint')),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: i18n.t('productions.home.filters.scrollHint') }),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^(Meer|More)$/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^(Minder|Less)$/ })).not.toBeInTheDocument()
+  })
 
-    fireEvent.click(
-      screen.getByRole('button', { name: i18n.t('productions.home.filters.showLess') }),
-    )
+  it('does not create a scroll region when five or fewer chip options are available', () => {
+    renderPanel({
+      genres: [
+        buildGenre({ id: 1, name: { nl: 'Alpha' } }),
+        buildGenre({ id: 2, name: { nl: 'Bravo' } }),
+        buildGenre({ id: 3, name: { nl: 'Charlie' } }),
+        buildGenre({ id: 4, name: { nl: 'Delta' } }),
+        buildGenre({ id: 5, name: { nl: 'Echo' } }),
+      ],
+    })
 
-    expect(screen.getAllByTestId(/chip-genre-/).map((chip) => chip.textContent)).toEqual([
-      'Alpha',
-      'Bravo',
-      'Charlie',
-      'Delta',
-      'Echo',
-    ])
+    expect(
+      screen.queryByRole('region', { name: i18n.t('productions.home.filters.scrollHint') }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(i18n.t('productions.home.filters.scrollHint')),
+    ).not.toBeInTheDocument()
   })
 
   it('adds and removes genre and tag ids when chips are toggled', () => {

--- a/frontend/src/components/filter-panel/ChipFilterSection.tsx
+++ b/frontend/src/components/filter-panel/ChipFilterSection.tsx
@@ -1,13 +1,18 @@
-import ExpandLessIcon from '@mui/icons-material/ExpandLess'
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
-import { Box, Button, Stack, Typography } from '@mui/material'
-import { useMemo, useState } from 'react'
+import { Box, Stack, Typography } from '@mui/material'
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { tokens } from '../../theme/tokens'
 import GenreAndTagChip from '../chips/GenreAndTagChip'
 
-const DEFAULT_VISIBLE_COUNT = 5
+const VISIBLE_CHIP_COUNT = 5
+const CHIP_ROW_HEIGHT_PX = 32
+const CHIP_ROW_GAP_PX = 6
+const CHIP_ROW_PEEK_PX = 12
+const SCROLL_CONTAINER_MAX_HEIGHT_PX =
+  VISIBLE_CHIP_COUNT * CHIP_ROW_HEIGHT_PX +
+  (VISIBLE_CHIP_COUNT - 1) * CHIP_ROW_GAP_PX +
+  CHIP_ROW_PEEK_PX
 
 export type ChipOption = {
   id: number
@@ -24,7 +29,7 @@ type ChipFilterSectionProps = {
 }
 
 /**
- * Renders a list of genre/tag chips with show-more/less overflow handling.
+ * Renders a list of genre/tag chips in a compact scroll area.
  * Selected options are sorted to the top, then alphabetically within each group.
  */
 const ChipFilterSection = ({
@@ -34,7 +39,6 @@ const ChipFilterSection = ({
   onToggle,
 }: ChipFilterSectionProps) => {
   const { t } = useTranslation()
-  const [showAll, setShowAll] = useState(false)
 
   const sortedOptions = useMemo(
     () =>
@@ -57,43 +61,55 @@ const ChipFilterSection = ({
     )
   }
 
-  const visibleOptions = showAll ? sortedOptions : sortedOptions.slice(0, DEFAULT_VISIBLE_COUNT)
-  const hasOverflow = sortedOptions.length > DEFAULT_VISIBLE_COUNT
+  const hasOverflow = sortedOptions.length > VISIBLE_CHIP_COUNT
 
   return (
     <Stack spacing={tokens.spacing.numericXs}>
-      <Stack spacing={0.75}>
-        {visibleOptions.map((option) => (
-          <Box key={`${option.chipType}-${option.id}`}>
-            <GenreAndTagChip
-              id={option.id}
-              name={option.name}
-              labels={option.labels}
-              chipType={option.chipType}
-              context="search"
-              selected={selectedIds.includes(option.id)}
-              onToggle={() => onToggle(option.id)}
-            />
-          </Box>
-        ))}
-      </Stack>
-
-      {hasOverflow && (
-        <Box>
-          <Button
-            size="small"
-            onClick={() => setShowAll((prev) => !prev)}
-            endIcon={
-              showAll ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />
-            }
-            sx={{ color: 'text.secondary', px: 0, fontSize: tokens.typography.sizes.xs }}
-          >
-            {showAll
-              ? t('productions.home.filters.showLess')
-              : t('productions.home.filters.showMore')}
-          </Button>
-        </Box>
-      )}
+      <Box
+        role={hasOverflow ? 'region' : undefined}
+        aria-label={hasOverflow ? t('productions.home.filters.scrollHint') : undefined}
+        tabIndex={hasOverflow ? 0 : undefined}
+        sx={(theme) => ({
+          maxHeight: hasOverflow ? `${SCROLL_CONTAINER_MAX_HEIGHT_PX}px` : 'none',
+          overflowY: hasOverflow ? 'auto' : 'visible',
+          borderRadius: tokens.borderRadius.md,
+          outline: 'none',
+          scrollbarWidth: hasOverflow ? 'thin' : 'auto',
+          scrollbarColor: hasOverflow
+            ? `${theme.palette.text.disabled} ${theme.palette.action.hover}`
+            : undefined,
+          '&:focus-visible': {
+            boxShadow: `0 0 0 2px ${theme.palette.primary.main}`,
+          },
+          '&::-webkit-scrollbar': {
+            width: 6,
+          },
+          '&::-webkit-scrollbar-track': {
+            backgroundColor: theme.palette.action.hover,
+            borderRadius: tokens.borderRadius.full,
+          },
+          '&::-webkit-scrollbar-thumb': {
+            backgroundColor: theme.palette.text.disabled,
+            borderRadius: tokens.borderRadius.full,
+          },
+        })}
+      >
+        <Stack spacing={0.75}>
+          {sortedOptions.map((option) => (
+            <Box key={`${option.chipType}-${option.id}`}>
+              <GenreAndTagChip
+                id={option.id}
+                name={option.name}
+                labels={option.labels}
+                chipType={option.chipType}
+                context="search"
+                selected={selectedIds.includes(option.id)}
+                onToggle={() => onToggle(option.id)}
+              />
+            </Box>
+          ))}
+        </Stack>
+      </Box>
     </Stack>
   )
 }

--- a/frontend/src/components/filter-panel/ChipFilterSection.tsx
+++ b/frontend/src/components/filter-panel/ChipFilterSection.tsx
@@ -1,5 +1,6 @@
-import { Box, Stack, Typography } from '@mui/material'
-import { useMemo } from 'react'
+import SearchIcon from '@mui/icons-material/Search'
+import { Box, InputAdornment, Stack, TextField, Typography } from '@mui/material'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { tokens } from '../../theme/tokens'
@@ -29,8 +30,9 @@ type ChipFilterSectionProps = {
 }
 
 /**
- * Renders a list of genre/tag chips in a compact scroll area.
- * Selected options are sorted to the top, then alphabetically within each group.
+ * A filter section that displays a list of options as chips, with an optional search field if there are many options.
+ * The options are sorted with selected ones first, and then alphabetically. When the number of options exceeds a certain threshold,
+ * a search field is shown to filter the options by name. The container becomes scrollable to show all options while hinting at overflow.
  */
 const ChipFilterSection = ({
   options,
@@ -39,6 +41,16 @@ const ChipFilterSection = ({
   onToggle,
 }: ChipFilterSectionProps) => {
   const { t } = useTranslation()
+  const [query, setQuery] = useState('')
+
+  const hasOverflow = options.length > VISIBLE_CHIP_COUNT
+
+  // Determine which search placeholder to use based on chipType
+  const chipType = options.length > 0 ? options[0].chipType : 'genre'
+  const searchPlaceholder =
+    chipType === 'genre'
+      ? t('productions.home.filters.searchGenres')
+      : t('productions.home.filters.searchTags')
 
   const sortedOptions = useMemo(
     () =>
@@ -53,6 +65,14 @@ const ChipFilterSection = ({
     [options, selectedIds],
   )
 
+  const filteredOptions = useMemo(() => {
+    const trimmed = query.trim().toLowerCase()
+    if (!trimmed) {
+      return sortedOptions
+    }
+    return sortedOptions.filter((option) => option.name.toLowerCase().includes(trimmed))
+  }, [sortedOptions, query])
+
   if (!sortedOptions.length) {
     return (
       <Typography variant="body2" color="text.secondary">
@@ -61,55 +81,89 @@ const ChipFilterSection = ({
     )
   }
 
-  const hasOverflow = sortedOptions.length > VISIBLE_CHIP_COUNT
-
   return (
     <Stack spacing={tokens.spacing.numericXs}>
-      <Box
-        role={hasOverflow ? 'region' : undefined}
-        aria-label={hasOverflow ? t('productions.home.filters.scrollHint') : undefined}
-        tabIndex={hasOverflow ? 0 : undefined}
-        sx={(theme) => ({
-          maxHeight: hasOverflow ? `${SCROLL_CONTAINER_MAX_HEIGHT_PX}px` : 'none',
-          overflowY: hasOverflow ? 'auto' : 'visible',
-          borderRadius: tokens.borderRadius.md,
-          outline: 'none',
-          scrollbarWidth: hasOverflow ? 'thin' : 'auto',
-          scrollbarColor: hasOverflow
-            ? `${theme.palette.text.disabled} ${theme.palette.action.hover}`
-            : undefined,
-          '&:focus-visible': {
-            boxShadow: `0 0 0 2px ${theme.palette.primary.main}`,
-          },
-          '&::-webkit-scrollbar': {
-            width: 6,
-          },
-          '&::-webkit-scrollbar-track': {
-            backgroundColor: theme.palette.action.hover,
-            borderRadius: tokens.borderRadius.full,
-          },
-          '&::-webkit-scrollbar-thumb': {
-            backgroundColor: theme.palette.text.disabled,
-            borderRadius: tokens.borderRadius.full,
-          },
-        })}
-      >
-        <Stack spacing={0.75}>
-          {sortedOptions.map((option) => (
-            <Box key={`${option.chipType}-${option.id}`}>
-              <GenreAndTagChip
-                id={option.id}
-                name={option.name}
-                labels={option.labels}
-                chipType={option.chipType}
-                context="search"
-                selected={selectedIds.includes(option.id)}
-                onToggle={() => onToggle(option.id)}
-              />
-            </Box>
-          ))}
-        </Stack>
-      </Box>
+      {hasOverflow && (
+        <TextField
+          size="small"
+          fullWidth
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={searchPlaceholder}
+          slotProps={{
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon sx={{ fontSize: 16, color: 'text.disabled' }} />
+                </InputAdornment>
+              ),
+            },
+          }}
+          sx={(theme) => ({
+            '& .MuiOutlinedInput-root': {
+              mb: 1 / 3,
+              borderRadius: tokens.borderRadius.md,
+              fontSize: theme.typography.body2.fontSize,
+              '& fieldset': {
+                borderColor: theme.palette.divider,
+              },
+            },
+            '& .MuiOutlinedInput-input': {
+              py: '6px',
+            },
+          })}
+        />
+      )}
+
+      {!filteredOptions.length ? (
+        <Typography variant="body2" color="text.secondary">
+          {emptyLabel}
+        </Typography>
+      ) : (
+        <Box
+          role={hasOverflow ? 'region' : undefined}
+          aria-label={hasOverflow ? t('productions.home.filters.scrollHint') : undefined}
+          tabIndex={hasOverflow ? 0 : undefined}
+          sx={(theme) => ({
+            maxHeight: hasOverflow ? `${SCROLL_CONTAINER_MAX_HEIGHT_PX}px` : 'none',
+            overflowY: hasOverflow ? 'auto' : 'visible',
+            borderRadius: tokens.borderRadius.md,
+            outline: 'none',
+            scrollbarWidth: hasOverflow ? 'thin' : 'auto',
+            scrollbarColor: hasOverflow
+              ? `${theme.palette.text.disabled} ${theme.palette.action.hover}`
+              : undefined,
+            '&:focus-visible': {
+              boxShadow: `0 0 0 2px ${theme.palette.primary.main}`,
+            },
+            '&::-webkit-scrollbar': { width: 6 },
+            '&::-webkit-scrollbar-track': {
+              backgroundColor: theme.palette.action.hover,
+              borderRadius: tokens.borderRadius.full,
+            },
+            '&::-webkit-scrollbar-thumb': {
+              backgroundColor: theme.palette.text.disabled,
+              borderRadius: tokens.borderRadius.full,
+            },
+          })}
+        >
+          <Stack spacing={0.75}>
+            {filteredOptions.map((option) => (
+              <Box key={`${option.chipType}-${option.id}`}>
+                <GenreAndTagChip
+                  id={option.id}
+                  name={option.name}
+                  labels={option.labels}
+                  chipType={option.chipType}
+                  context="search"
+                  selected={selectedIds.includes(option.id)}
+                  onToggle={() => onToggle(option.id)}
+                />
+              </Box>
+            ))}
+          </Stack>
+        </Box>
+      )}
     </Stack>
   )
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -135,7 +135,9 @@
         "showMore": "More",
         "showLess": "Less",
         "noGenres": "No genres available.",
-        "noTags": "No tags available."
+        "noTags": "No tags available.",
+        "searchGenres": "Search genres...",
+        "searchTags": "Search tags..."
       },
       "empty": {
         "title": "No productions found",

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -135,7 +135,9 @@
         "showMore": "Meer",
         "showLess": "Minder",
         "noGenres": "Geen genres beschikbaar.",
-        "noTags": "Geen tags beschikbaar."
+        "noTags": "Geen tags beschikbaar.",
+        "searchGenres": "Zoek genres...",
+        "searchTags": "Zoek tags..."
       },
       "empty": {
         "title": "Geen producties gevonden",


### PR DESCRIPTION
## Description
Make genres and tags in the filterpanel scrollable.

## Related Issues
- Closes #500

## Type of Change
- [x] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please specify): _____________

## Testing Instructions
Run automated tests and also verify manually on the archive page.

## Checklist for Reviewers
- [ ] Follows Style Guide
- [ ] Has Documentation (if applicable)
- [ ] Added Unit tests
- [ ] Tested in the relevant environments
