### PR TITLE
[FE][BUG] Carousel jitters and only advances one slide at a time

### DIFF
--- a/frontend/src/components/carousel/Carousel.tsx
+++ b/frontend/src/components/carousel/Carousel.tsx
@@ -47,9 +47,10 @@ function Carousel({
 }: CarouselProps) {
   const slides = useMemo(() => Children.toArray(children), [children])
 
-  const [emblaRef, emblaApi] = useEmblaCarousel({ align: 'start', loop, duration: 28 }, [
-    WheelGesturesPlugin(),
-  ])
+  const [emblaRef, emblaApi] = useEmblaCarousel(
+    { align: 'start', loop, duration: 28, slidesToScroll: 'auto' },
+    [WheelGesturesPlugin()],
+  )
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [canScrollPrev, setCanScrollPrev] = useState(false)
   const [canScrollNext, setCanScrollNext] = useState(false)
@@ -144,7 +145,13 @@ function Carousel({
           {slides.map((slide, index) => (
             <Box
               key={index}
-              sx={{ px: 1, boxSizing: 'border-box', display: 'flex', alignItems: 'stretch' }}
+              sx={{
+                flex: '0 0 auto',
+                px: 1,
+                boxSizing: 'border-box',
+                display: 'flex',
+                alignItems: 'stretch',
+              }}
             >
               {slide}
             </Box>

--- a/frontend/src/components/production/RelatedBlogs.tsx
+++ b/frontend/src/components/production/RelatedBlogs.tsx
@@ -43,6 +43,8 @@ function RelatedBlogs({ blogs }: RelatedBlogsProps) {
           <Box
             key={blog.id}
             sx={{
+              width: { xs: 'calc(100vw - 80px)', sm: tokens.card.gridCardWidthPx },
+              maxWidth: 'calc(100vw - 80px)',
               display: 'flex',
               alignItems: 'stretch',
               '& > a': {

--- a/frontend/src/components/production/RelatedProductions.tsx
+++ b/frontend/src/components/production/RelatedProductions.tsx
@@ -101,6 +101,8 @@ function RelatedProductions({ lang = 'nl', related, showTag = true }: RelatedPro
                   <Box
                     key={production.id}
                     sx={{
+                      width: { xs: 'calc(100vw - 80px)', sm: tokens.card.gridCardWidthPx },
+                      maxWidth: 'calc(100vw - 80px)',
                       display: 'flex',
                       alignItems: 'stretch',
                       // make the inner ProductionGridCard fill the slide height


### PR DESCRIPTION
## Description
Stabilizes Embla carousel layout for **related productions** and **related blogs** so slide widths do not shrink and re-measure after paint. That re-measurement was triggering Embla’s resize handling (`reInit`) during programmatic scroll, which made arrow/dot navigation look like the animation was **cut short** or **jittery**. The generic carousel slide wrapper is also marked `flex: 0 0 auto` so slides are not flex-shrunk in the horizontal track.

## Related Issues
- Closes #528

## Type of Change
- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please specify): _____________

## Testing Instructions
Make sure all automated tests still pass.
Try to reproduce the bug on a production detail page which has some media and related productions or blogs.

## Checklist for Reviewers
- [ ] Follows Style Guide
- [ ] Has Documentation (if applicable)
- [ ] Added Unit tests
- [ ] Tested in the relevant environments
