### PR TITLE
534 scrollable events list

### DIFF
--- a/frontend/src/features/productions/components/detail/EventList.tsx
+++ b/frontend/src/features/productions/components/detail/EventList.tsx
@@ -73,163 +73,178 @@ export default function EventsList({ events }: EventsListProps) {
     })
 
   return (
-    <Stack spacing={0} divider={<Divider sx={{ my: 1.5 }} />}>
-      {events.map((event) => {
-        const expanded = expandedIds.has(event.id)
-        const hasPrices = event.prices?.length > 0
+    <Box
+      sx={{
+        maxHeight: 380,
+        overflowY: 'auto',
+        scrollbarWidth: 'thin',
+        scrollbarColor: (theme) => `${theme.palette.action.selected} transparent`,
+      }}
+    >
+      <Stack spacing={0} divider={<Divider sx={{ my: 1.5 }} />}>
+        {events.map((event) => {
+          const expanded = expandedIds.has(event.id)
+          const hasPrices = event.prices?.length > 0
 
-        return (
-          <Box key={event.id}>
-            {/* Event row container: holds date/time/venue + optional expand button */}
-            <Stack
-              direction="row"
-              sx={(theme) => ({
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                color: theme.palette.text.primary,
-              })}
-            >
-              <Stack spacing={0.5} sx={{ flex: 1, minWidth: 0 }}>
-                {/* Date + time block */}
-                <Stack direction="row" spacing={2} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
-                  {/* Event start date */}
-                  <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
-                    <CalendarTodayOutlinedIcon sx={{ fontSize: '0.95rem' }} />
-                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                      {event.starts_at ? formatDate(event.starts_at, lang) : '—'}
-                    </Typography>
-                  </Stack>
-
-                  {/* Event time range (only shown if start exists) */}
-                  {event.starts_at && (
-                    <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
-                      <ScheduleOutlinedIcon sx={{ fontSize: '0.95rem' }} />
-                      <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                        {formatTime(event.starts_at, lang)}
-                        {event.ends_at ? ` - ${formatTime(event.ends_at, lang)}` : ''}
-                      </Typography>
-                    </Stack>
-                  )}
-                </Stack>
-
-                {/* Venue / hall display (only shown when available) */}
-                {(() => {
-                  const hallName = getHallDisplayName(event, lang)
-                  return (
-                    hallName && (
-                      <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
-                        <RoomOutlinedIcon sx={{ fontSize: '0.9rem' }} />
-                        <Typography variant="body2">{hallName}</Typography>
-                      </Stack>
-                    )
-                  )
-                })()}
-              </Stack>
-
-              {/* Right-side action area (expand prices if available) */}
+          return (
+            <Box key={event.id}>
+              {/* Event row container: holds date/time/venue + optional expand button */}
               <Stack
                 direction="row"
-                spacing={1}
-                sx={{ alignItems: 'center', flexShrink: 0, ml: 2 }}
+                sx={(theme) => ({
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  color: theme.palette.text.primary,
+                })}
               >
-                {/* Only render toggle if price data exists */}
-                {hasPrices && (
-                  <IconButton
-                    size="small"
-                    onClick={() => toggle(event.id)}
-                    aria-expanded={expanded}
-                    aria-label={
-                      expanded
-                        ? t('events.collapsePrices', 'Prijzen verbergen')
-                        : t('events.expandPrices', 'Prijzen tonen')
-                    }
+                <Stack spacing={0.5} sx={{ flex: 1, minWidth: 0 }}>
+                  {/* Date + time block */}
+                  <Stack
+                    direction="row"
+                    spacing={2}
+                    sx={{ alignItems: 'center', flexWrap: 'wrap' }}
+                  >
+                    {/* Event start date */}
+                    <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
+                      <CalendarTodayOutlinedIcon sx={{ fontSize: '0.95rem' }} />
+                      <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                        {event.starts_at ? formatDate(event.starts_at, lang) : '—'}
+                      </Typography>
+                    </Stack>
+
+                    {/* Event time range (only shown if start exists) */}
+                    {event.starts_at && (
+                      <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
+                        <ScheduleOutlinedIcon sx={{ fontSize: '0.95rem' }} />
+                        <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                          {formatTime(event.starts_at, lang)}
+                          {event.ends_at ? ` - ${formatTime(event.ends_at, lang)}` : ''}
+                        </Typography>
+                      </Stack>
+                    )}
+                  </Stack>
+
+                  {/* Venue / hall display (only shown when available) */}
+                  {(() => {
+                    const hallName = getHallDisplayName(event, lang)
+                    return (
+                      hallName && (
+                        <Stack direction="row" spacing={0.75} sx={{ alignItems: 'center' }}>
+                          <RoomOutlinedIcon sx={{ fontSize: '0.9rem' }} />
+                          <Typography variant="body2">{hallName}</Typography>
+                        </Stack>
+                      )
+                    )
+                  })()}
+                </Stack>
+
+                {/* Right-side action area (expand prices if available) */}
+                <Stack
+                  direction="row"
+                  spacing={1}
+                  sx={{ alignItems: 'center', flexShrink: 0, ml: 2 }}
+                >
+                  {/* Only render toggle if price data exists */}
+                  {hasPrices && (
+                    <IconButton
+                      size="small"
+                      onClick={() => toggle(event.id)}
+                      aria-expanded={expanded}
+                      aria-label={
+                        expanded
+                          ? t('events.collapsePrices', 'Prijzen verbergen')
+                          : t('events.expandPrices', 'Prijzen tonen')
+                      }
+                      sx={(theme) => ({
+                        border: `1px solid ${theme.palette.divider}`,
+                        borderRadius: tokens.borderRadius.sm,
+                      })}
+                    >
+                      {/* Icon rotates to indicate expanded/collapsed state */}
+                      <ExpandMoreIcon
+                        fontSize="small"
+                        sx={{
+                          transition: 'transform 200ms ease',
+                          transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                        }}
+                      />
+                    </IconButton>
+                  )}
+                </Stack>
+              </Stack>
+
+              {/* Collapsible price table section */}
+              {hasPrices && (
+                <Collapse in={expanded} unmountOnExit>
+                  <Box
                     sx={(theme) => ({
+                      mt: 1.5,
                       border: `1px solid ${theme.palette.divider}`,
                       borderRadius: tokens.borderRadius.sm,
+                      overflow: 'hidden',
                     })}
                   >
-                    {/* Icon rotates to indicate expanded/collapsed state */}
-                    <ExpandMoreIcon
-                      fontSize="small"
-                      sx={{
-                        transition: 'transform 200ms ease',
-                        transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
-                      }}
-                    />
-                  </IconButton>
-                )}
-              </Stack>
-            </Stack>
-
-            {/* Collapsible price table section */}
-            {hasPrices && (
-              <Collapse in={expanded} unmountOnExit>
-                <Box
-                  sx={(theme) => ({
-                    mt: 1.5,
-                    border: `1px solid ${theme.palette.divider}`,
-                    borderRadius: tokens.borderRadius.sm,
-                    overflow: 'hidden',
-                  })}
-                >
-                  <Table size="small">
-                    {/* Table header describing price structure */}
-                    <TableHead>
-                      <TableRow>
-                        <TableCell sx={{ fontWeight: tokens.typography.weights.bold }}>
-                          {t('events.priceType', 'Type')}
-                        </TableCell>
-                        <TableCell
-                          align="right"
-                          sx={{ fontWeight: tokens.typography.weights.bold }}
-                        >
-                          {t('events.price', 'Prijs')}
-                        </TableCell>
-                        <TableCell
-                          align="right"
-                          sx={{ fontWeight: tokens.typography.weights.bold }}
-                        >
-                          {t('events.available', 'Beschikbaar')}
-                        </TableCell>
-                      </TableRow>
-                    </TableHead>
-
-                    {/* Price rows per ticket type */}
-                    <TableBody>
-                      {event.prices.map((p) => (
-                        <TableRow key={p.id} hover>
-                          {/* Price category / description */}
-                          <TableCell>{p.price?.description?.[lang] || p.price_display}</TableCell>
-
-                          {/* Price value formatted as EUR */}
-                          <TableCell align="right">
-                            <Typography variant="body2">€{Number(p.amount).toFixed(2)}</Typography>
+                    <Table size="small">
+                      {/* Table header describing price structure */}
+                      <TableHead>
+                        <TableRow>
+                          <TableCell sx={{ fontWeight: tokens.typography.weights.bold }}>
+                            {t('events.priceType', 'Type')}
                           </TableCell>
-
-                          {/* Availability indicator (can be null) */}
-                          <TableCell align="right">
-                            <Typography
-                              variant="body2"
-                              sx={(theme) => ({
-                                color:
-                                  theme.palette.mode === DarkMode
-                                    ? tokens.colors.dark.textMuted
-                                    : tokens.colors.light.textMuted,
-                              })}
-                            >
-                              {p.available ?? '-'}
-                            </Typography>
+                          <TableCell
+                            align="right"
+                            sx={{ fontWeight: tokens.typography.weights.bold }}
+                          >
+                            {t('events.price', 'Prijs')}
+                          </TableCell>
+                          <TableCell
+                            align="right"
+                            sx={{ fontWeight: tokens.typography.weights.bold }}
+                          >
+                            {t('events.available', 'Beschikbaar')}
                           </TableCell>
                         </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </Box>
-              </Collapse>
-            )}
-          </Box>
-        )
-      })}
-    </Stack>
+                      </TableHead>
+
+                      {/* Price rows per ticket type */}
+                      <TableBody>
+                        {event.prices.map((p) => (
+                          <TableRow key={p.id} hover>
+                            {/* Price category / description */}
+                            <TableCell>{p.price?.description?.[lang] || p.price_display}</TableCell>
+
+                            {/* Price value formatted as EUR */}
+                            <TableCell align="right">
+                              <Typography variant="body2">
+                                €{Number(p.amount).toFixed(2)}
+                              </Typography>
+                            </TableCell>
+
+                            {/* Availability indicator (can be null) */}
+                            <TableCell align="right">
+                              <Typography
+                                variant="body2"
+                                sx={(theme) => ({
+                                  color:
+                                    theme.palette.mode === DarkMode
+                                      ? tokens.colors.dark.textMuted
+                                      : tokens.colors.light.textMuted,
+                                })}
+                              >
+                                {p.available ?? '-'}
+                              </Typography>
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </Box>
+                </Collapse>
+              )}
+            </Box>
+          )
+        })}
+      </Stack>
+    </Box>
   )
 }

--- a/frontend/src/features/productions/components/detail/EventList.tsx
+++ b/frontend/src/features/productions/components/detail/EventList.tsx
@@ -75,7 +75,7 @@ export default function EventsList({ events }: EventsListProps) {
   return (
     <Box
       sx={{
-        maxHeight: 380,
+        maxHeight: 345,
         overflowY: 'auto',
         scrollbarWidth: 'thin',
         scrollbarColor: (theme) => `${theme.palette.action.selected} transparent`,


### PR DESCRIPTION
## Summary
Wrap the events list in a scrollable container so long event lists no longer push page content down.

## Changes
- Wrapped `Stack` in a scrollable `Box` in `EventsList` - no logic changes **(Other than that, I haven’t changed anything, so only lines 76-83 ( are different)**

## Testing
- [x] Open [https://sel2-2.ugent.be/nl/producties/2622](https://sel2-2.ugent.be/nl/producties/2622) - this production has a long list of events
- [x] Verify the events list scrolls independently within its container
- [x] Verify page layout is unaffected
- [x] Test on mobile (iOS + Android) - check scroll behavior and touch feel
- [x] Test with expanded price rows while scrolling
- [x] Verify dark mode scrollbar styling