### PR TITLE
Make footer same color as navbar

### DIFF
--- a/frontend/src/__tests__/theme/styles.test.ts
+++ b/frontend/src/__tests__/theme/styles.test.ts
@@ -95,7 +95,7 @@ describe('theme/styles - createCommonStyles', () => {
     const footerSx = commonStyles.footer as SxProps<Theme>
     const footerRecord = footerSx as Record<string, unknown>
 
-    expect(footerRecord.bgcolor).toBe(tokens.colors.neutral.gray900)
+    expect(footerRecord.bgcolor).toBe(tokens.colors.neutral.black)
     expect(footerRecord.color).toBe(tokens.colors.neutral.white)
     expect(footerRecord.mt).toBe(tokens.spacing.numericLg)
   })

--- a/frontend/src/theme/styles.ts
+++ b/frontend/src/theme/styles.ts
@@ -151,7 +151,7 @@ export const createCommonStyles = (theme: Theme) => {
      * Footer container styling.
      */
     footer: {
-      bgcolor: tokens.colors.neutral.gray900,
+      bgcolor: tokens.colors.neutral.black,
       color: tokens.colors.neutral.white,
       borderTop: `1px solid ${tokens.colors.overlay.footerBorder}`,
       mt: tokens.spacing.numericLg,


### PR DESCRIPTION
Updated the navbar background to solid black using theme tokens for better contrast and separation from the page content.

Before: 
<img width="1853" height="1003" alt="image" src="https://github.com/user-attachments/assets/26d482fd-78e5-486d-955d-cbe89f4cdb42" />

After: 
<img width="1853" height="1003" alt="image" src="https://github.com/user-attachments/assets/7889331e-3444-46e2-a65c-e8748d83f82f" />

