### PR TITLE
[Be] mandatory tag name

### DIFF
--- a/backend/apps/tags/admin.py
+++ b/backend/apps/tags/admin.py
@@ -2,13 +2,12 @@
 Admin configuration for the Tags app.
 
 The admin is structured around the ``Tag`` model as the primary entry point,
-with an inline for translations. A standalone ``TagTranslationAdmin`` is
-provided for filtering translations by language across all tags.
+with an inline for translations.
 
 Queryset optimisation
 ---------------------
 ``TagAdmin`` prefetches translations to prevent N+1 queries on the list page.
-``TagTranslationAdmin`` uses ``select_related`` to join the parent tag and
+``TagTranslationInline`` uses ``select_related`` to join the parent tag and
 language in a single query.
 """
 
@@ -45,6 +44,18 @@ class TagAdminForm(forms.ModelForm):
         }
 
 
+class TagTranslationInlineFormSet(forms.models.BaseInlineFormSet):
+    """Inline formset that enforces at least one non-deleted translation."""
+
+    def clean(self) -> None:
+        """Raise an error if all translations are marked for deletion."""
+        super().clean()
+
+        non_deleted_count = sum(1 for form in self.forms if form.cleaned_data and not form.cleaned_data.get("DELETE", False))
+        if non_deleted_count < 1:
+            raise forms.ValidationError("A tag must have at least one translation.")
+
+
 class TagTranslationInline(admin.StackedInline):
     """
     Inline for editing localised tag fields directly inside the Tag change page.
@@ -52,10 +63,10 @@ class TagTranslationInline(admin.StackedInline):
 
     model = TagTranslation
     extra = 1
+    formset = TagTranslationInlineFormSet
     autocomplete_fields = ("language",)
     fields = ("language", "name", "excerpt", "short_description", "url_title")
     ordering = ("language__code",)
-    classes = ("collapse",)
 
     def get_queryset(self, request: HttpRequest) -> QuerySet:
         """Select related language to avoid N+1 queries in the translation inline."""

--- a/backend/apps/tags/models.py
+++ b/backend/apps/tags/models.py
@@ -30,6 +30,11 @@ class Tag(BaseModel):
     external systems (e.g. UiTdatabank). The ``source`` field records
     the origin of the tag.
 
+    Every tag must have at least one ``TagTranslation`` once it has been
+    persisted. New tags can be created without translations, but any
+    subsequent save of an existing tag that has no translations will raise
+    a ``ValidationError``.
+
     Attributes:
         url:         Public URL of the tag in the originating system.
         source:      Identifier of the system that created this tag
@@ -74,8 +79,12 @@ class Tag(BaseModel):
     )
 
     def clean(self) -> None:
-        """Validate uploaded image files."""
+        """Validate uploaded image files and enforce at least one translation."""
         super().clean()
+
+        if self.pk and not self.translations.exists():
+            raise ValidationError({"translations": "A tag must have at least one translation."})
+
         uploaded_image = getattr(self.image, "_file", None)
         if isinstance(uploaded_image, UploadedFile):
             try:
@@ -108,13 +117,14 @@ class TagTranslation(BaseModel):
     """Localised text fields for a Tag.
 
     Each tag can have at most one translation per language. The ``name``
-    field is the primary display label; ``excerpt``, ``short_description``
-    and ``url_title`` are optional supplementary fields.
+    field is required and serves as the primary display label;
+    ``excerpt``, ``short_description`` and ``url_title`` are optional
+    supplementary fields.
 
     Attributes:
         tag:               The tag this translation belongs to.
         language:          The language of this translation.
-        name:              Localised display name of the tag.
+        name:              Localised display name of the tag (required).
         excerpt:          Optional excerpt or summary of the tag.
         short_description: Optional short description of the tag.
         url_title:         URL-safe title used in slugs or links.
@@ -138,6 +148,8 @@ class TagTranslation(BaseModel):
 
     name = models.CharField(
         max_length=255,
+        null=False,
+        blank=False,
         help_text="Localised display name of the tag (e.g. `Contemporary`, `Family friendly`).",
         db_comment="The name of the tag in the specified language.",
     )

--- a/backend/apps/tags/schemas.py
+++ b/backend/apps/tags/schemas.py
@@ -120,7 +120,8 @@ _TAG_CREATE = extend_schema(
         "Creates a new **Tag**.\n\n"
         "- `type` is used as a classification label (e.g. `theme`, `audience`).\n"
         "- Localised fields (`name`, `excerpt`, `short_description`, `url_title`) must be added "
-        "via the **Tag Translation** endpoints after creation.\n\n"
+        "via the **Tag Translation** endpoints after creation. "
+        "`name` is mandatory for every translation.\n\n"
         "> **Requires an internal API key.**"
     ),
     request=TagSerializer,
@@ -131,7 +132,10 @@ _TAG_CREATE = extend_schema(
 _TAG_UPDATE = extend_schema(
     summary="Replace a tag",
     description=(
-        "Fully replaces an existing **Tag**. All writable fields must be supplied.\n\n> **Requires an internal API key.**"
+        "Fully replaces an existing **Tag**. All writable fields must be supplied.\n\n"
+        "Existing tags must have at least one translation; attempting to update a tag "
+        "that has no translations will fail with a validation error.\n\n"
+        "> **Requires an internal API key.**"
     ),
     request=TagSerializer,
     responses={200: TagSerializer, **MUTATE_ERRORS},
@@ -143,6 +147,8 @@ _TAG_PARTIAL_UPDATE = extend_schema(
     description=(
         "Updates one or more fields of an existing **Tag** without "
         "requiring a full payload.\n\n"
+        "Existing tags must have at least one translation; attempting to update a tag "
+        "that has no translations will fail with a validation error.\n\n"
         "> **Requires an internal API key.**"
     ),
     request=TagSerializer,

--- a/backend/tests/tags/test_tag_admin.py
+++ b/backend/tests/tags/test_tag_admin.py
@@ -3,24 +3,30 @@ Tests for apps/tags/admin.py
 
 Covers:
 - TagAdmin is registered
-- TagTranslationAdmin is registered
-- list_display configuration for both admins
-- list_filter configuration for both admins
-- search_fields configuration for both admins
+- list_display configuration
+- list_filter configuration
+- search_fields configuration
 - autocomplete_fields configuration
 - TagTranslationInline is present on TagAdmin
-- Both admins inherit from BaseAdmin
+- TagAdmin inherits from BaseAdmin
 - Functional admin changelist and changeform (with superuser)
+- TagTranslationInline formset enforces at least one translation
 """
 
 from django.contrib import admin
 from django.contrib.auth.models import User
+from django.forms.models import inlineformset_factory
 from django.test import TestCase
 from django.urls import reverse
 
 from apps.core.admin import BaseAdmin
 from apps.productions.models import ProductionTag
-from apps.tags.admin import TagAdmin, TagProductionInline, TagTranslationInline
+from apps.tags.admin import (
+    TagAdmin,
+    TagProductionInline,
+    TagTranslationInline,
+    TagTranslationInlineFormSet,
+)
 from apps.tags.models import Tag, TagTranslation
 from tests.factories.language import LanguageFactory
 from tests.factories.tag import TagFactory
@@ -125,6 +131,38 @@ class TestTagTranslationInlineConfiguration(TestCase):
 
     def test_inline_autocomplete_fields_contains_language(self) -> None:
         assert "language" in self.inline.autocomplete_fields
+
+    def test_inline_formset_requires_at_least_one_translation(self) -> None:
+        """Submitting a changeform that deletes the only translation must fail."""
+        tag = TagFactory.create(type="genre")
+        lang = LanguageFactory(code="en", name="English")
+        translation = TagTranslation.objects.create(tag=tag, language=lang, name="Test")
+
+        formset_class = inlineformset_factory(
+            Tag,
+            TagTranslation,
+            formset=TagTranslationInlineFormSet,
+            fields=("language", "name"),
+            extra=0,
+        )
+
+        # Simulate a formset with the existing translation marked for deletion
+        data = {
+            "translations-TOTAL_FORMS": "1",
+            "translations-INITIAL_FORMS": "1",
+            "translations-MIN_NUM_FORMS": "0",
+            "translations-MAX_NUM_FORMS": "1000",
+            "translations-0-id": str(translation.id),
+            "translations-0-tag": str(tag.id),
+            "translations-0-language": str(lang.code),
+            "translations-0-name": "Test",
+            "translations-0-DELETE": "on",
+        }
+
+        formset = formset_class(data, instance=tag, prefix="translations")
+
+        assert not formset.is_valid()
+        assert "A tag must have at least one translation." in str(formset.non_form_errors())
 
 
 class TestTagProductionInlineConfiguration(TestCase):

--- a/backend/tests/tags/test_tag_models.py
+++ b/backend/tests/tags/test_tag_models.py
@@ -70,6 +70,33 @@ class TestTag:
 
         assert "image" in exc.value.message_dict
 
+    def test_new_tag_can_be_created_without_translations(self) -> None:
+        """New tags are exempt from the translation requirement because
+        translations are added after creation."""
+        tag = TagFactory()
+        assert tag.pk is not None
+        assert tag.translations.count() == 0
+
+    def test_existing_tag_cannot_be_saved_without_translations(self) -> None:
+        """Once a tag exists, it must retain at least one translation."""
+        tag = TagFactory()
+        # Tag was created without translations (new-tag exemption)
+        assert tag.translations.count() == 0
+
+        with pytest.raises(ValidationError) as exc:
+            tag.save()
+
+        assert "translations" in exc.value.message_dict
+
+    def test_existing_tag_with_translations_can_be_saved(self) -> None:
+        """A tag that has translations can be saved normally."""
+        tag = TagFactory()
+        TagTranslationFactory(tag=tag, language__code="en", name="Rock")
+
+        tag.save()  # should not raise
+
+        assert tag.translations.count() == 1
+
 
 # =====================================================
 # TagTranslation

--- a/backend/tests/tags/test_tag_serializers.py
+++ b/backend/tests/tags/test_tag_serializers.py
@@ -364,6 +364,7 @@ class TestTagSerializerDeserialization(TestCase):
 
     def test_partial_update_with_single_field(self) -> None:
         tag = TagFactory.create(type="genre", is_enabled=True)
+        TagTranslationFactory(tag=tag, language__code="en", name="Genre")
         serializer = TagSerializer(tag, data={"is_enabled": False}, partial=True)
         assert serializer.is_valid(), serializer.errors
         updated = serializer.save()
@@ -371,6 +372,7 @@ class TestTagSerializerDeserialization(TestCase):
 
     def test_partial_update_does_not_touch_other_fields(self) -> None:
         tag = TagFactory.create(type="genre", source="manual")
+        TagTranslationFactory(tag=tag, language__code="en", name="Genre")
         serializer = TagSerializer(tag, data={"is_enabled": False}, partial=True)
         assert serializer.is_valid()
         updated = serializer.save()

--- a/backend/tests/tags/test_tag_views.py
+++ b/backend/tests/tags/test_tag_views.py
@@ -254,6 +254,7 @@ class TestTagViewSetUpdate(TestCase):
     def setUp(self):
         self.client = APIClient()
         self.tag = TagFactory.create(type="genre")
+        TagTranslationFactory(tag=self.tag, language__code="en", name="Genre")
         self.payload = {
             "type": "updated-genre",
             "source": "system",
@@ -288,6 +289,7 @@ class TestTagViewSetPartialUpdate(TestCase):
     def setUp(self):
         self.client = APIClient()
         self.tag = TagFactory.create(type="genre", is_enabled=True)
+        TagTranslationFactory(tag=self.tag, language__code="en", name="Genre")
 
     def test_patch_with_internal_key_returns_200(self):
         response = self.client.patch(


### PR DESCRIPTION
# [Be] mandatory tag name
This PR add a check in the backend to make sure that a tag has at least one translation. This fixes the issue that the frontend may need to work with tags that have no name.

## Related Issues
- closes #541 

## Type of Change
- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please specify): _____________

## Testing Instructions
- Open the CMS and try to add a tag without a translation, you should see an error.
- When you add a translation (without a name) you should also get an error.
- When you delete the only translation of a tag you should see an error.
- When you remove the name field from a tag translation, you should see an error.

## Checklist for Reviewers
- [ ] Follows Style Guide
- [ ] Has Documentation (if applicable)
- [ ] Added Unit tests
- [ ] Tested in the relevant environments
