### PR TITLE
[FE] Fix translation of 'loading' display of productions on SeriesDetailPage

### DIFF
--- a/frontend/src/__tests__/features/series/pages/SeriesDetailPage.test.tsx
+++ b/frontend/src/__tests__/features/series/pages/SeriesDetailPage.test.tsx
@@ -43,7 +43,7 @@ jest.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string, fallback?: string) => {
       const translations: Record<string, string> = {
-        'common.loading': 'Loading…',
+        'common.loading': 'Laden…',
         'series.loading': 'Reeks laden',
         'series.backToSeries': 'Terug naar reeksen',
         'series.allEditions': 'Alle edities',
@@ -487,7 +487,7 @@ describe('SeriesDetailPage', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Toon meer' }))
 
     const loadingButton = await screen.findByRole('button', {
-      name: 'Loading…',
+      name: 'Laden…',
     })
     expect(loadingButton).toBeDisabled()
 

--- a/frontend/src/features/series/pages/SeriesDetailPage.tsx
+++ b/frontend/src/features/series/pages/SeriesDetailPage.tsx
@@ -448,9 +448,7 @@ const SeriesDetailContent = ({ id }: SeriesDetailContentProps) => {
                   onClick={() => void loadMoreProductions()}
                   disabled={isLoadingMore}
                 >
-                  {isLoadingMore
-                    ? t('common.loading', 'Loading…')
-                    : t('series.showMore', 'Show More')}
+                  {isLoadingMore ? t('common.loading') : t('series.showMore', 'Show More')}
                 </Button>
               </Box>
             )}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -328,5 +328,8 @@
     "loading": "Loading media files",
     "resultsRegionLabel": "Media files results",
     "noDescription": "No description available."
+  },
+  "common": {
+    "loading": "Loading…"
   }
 }

--- a/frontend/src/locales/nl/translation.json
+++ b/frontend/src/locales/nl/translation.json
@@ -328,5 +328,8 @@
     "loading": "Mediabestanden laden",
     "resultsRegionLabel": "Resultaten van mediabestanden",
     "noDescription": "Geen beschrijving beschikbaar."
+  },
+  "common": {
+    "loading": "Laden…"
   }
 }


### PR DESCRIPTION
## Description
Fixes the Dutch series detail “Show more” loading state, where the button displayed `Loading…` on `/nl` instead of the localized Dutch text.

## Related Issues
- #543 

## Type of Change
- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please specify): _____________

## Testing Instructions
Run the relevant frontend tests:

```bash
npm test -- SeriesDetailPage.test.tsx