### PR TITLE
545 bug series redirect to not found instead of 404

### DIFF
--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -78,7 +78,12 @@ describe('App', () => {
 
     render(<App />)
 
-    // Not-found route is lazy loaded; wait for the heading to appear
+    // Unknown routes should settle on the localized 404 page.
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/nl/404')
+    })
+
+    // Not-found route is lazy loaded; wait for the heading to appear.
     expect(await screen.findByRole('heading', { name: 'Pagina niet gevonden' })).toBeInTheDocument()
     expect(
       await screen.findByText('De pagina die je zoekt bestaat niet of is verplaatst.'),

--- a/frontend/src/__tests__/features/series/pages/SeriesDetailPage.test.tsx
+++ b/frontend/src/__tests__/features/series/pages/SeriesDetailPage.test.tsx
@@ -128,7 +128,7 @@ describe('SeriesDetailPage', () => {
           <Route path="/:lang/reeksen/:id" element={<SeriesDetailPage />} />
           <Route path="/:lang/reeksen" element={<SeriesPageMock />} />
           <Route path="/:lang/producties/:id" element={<div>PRODUCTION DETAIL</div>} />
-          <Route path="/:lang/not-found" element={<div>404 PAGE</div>} />
+          <Route path="/:lang/404" element={<div>404 PAGE</div>} />
         </Routes>
       </MemoryRouter>,
     )

--- a/frontend/src/__tests__/router.test.tsx
+++ b/frontend/src/__tests__/router.test.tsx
@@ -129,7 +129,18 @@ describe('Router', () => {
     render(<Router mode="light" onToggleMode={jest.fn()} />)
 
     await waitFor(() => {
-      expect(window.location.pathname).toBe('/en/xx')
+      expect(window.location.pathname).toBe('/en/404')
+    })
+    expect(await screen.findByTestId('not-found-page-mock')).toBeInTheDocument()
+  })
+
+  it('redirects unknown localized routes to the localized 404 path', async () => {
+    window.history.pushState({}, '', '/nl/does-not-exist')
+
+    render(<Router mode="light" onToggleMode={jest.fn()} />)
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/nl/404')
     })
     expect(await screen.findByTestId('not-found-page-mock')).toBeInTheDocument()
   })

--- a/frontend/src/features/series/pages/SeriesDetailPage.tsx
+++ b/frontend/src/features/series/pages/SeriesDetailPage.tsx
@@ -136,7 +136,7 @@ const SeriesDetailContent = ({ id }: SeriesDetailContentProps) => {
     i18n.language,
     i18n.resolvedLanguage,
   )
-  const notFoundPath = toLocalizedPath('/not-found', currentLanguage)
+  const notFoundPath = toLocalizedPath('/404', currentLanguage)
 
   const [seriesTag, setSeriesTag] = useState<Tag | null>(null)
   const [seriesProductions, setSeriesProductions] = useState<Production[]>([])

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -80,6 +80,8 @@ const LocalizedLayout = ({ mode, onToggleMode }: ModeToggleProps) => {
   const { i18n, t } = useTranslation()
   const location = useLocation()
   const normalizedLanguage = normalizeLanguage(lang)
+  const notFoundLanguage = normalizedLanguage ?? DEFAULT_LANGUAGE
+  const notFoundPath = `${toLocalizedPath('/404', notFoundLanguage)}${location.search}${location.hash}`
 
   useLayoutEffect(() => {
     if (!normalizedLanguage || i18n.resolvedLanguage === normalizedLanguage) {
@@ -138,6 +140,7 @@ const LocalizedLayout = ({ mode, onToggleMode }: ModeToggleProps) => {
                 <Navigate to={localizedPath('/media')} replace state={mediaDetailAlertState} />
               }
             />
+            <Route path="404" element={<NotFoundPage />} />
             {/* Compatibility aliases from untranslated slug paths. */}
             {archiveSlug !== 'archive' && (
               <Route path="archive" element={<Navigate to={localizedPath('/archive')} replace />} />
@@ -216,7 +219,7 @@ const LocalizedLayout = ({ mode, onToggleMode }: ModeToggleProps) => {
                 }
               />
             )}
-            <Route path="*" element={<NotFoundPage />} />
+            <Route path="*" element={<Navigate to={notFoundPath} replace />} />
           </Routes>
         </Suspense>
       </Box>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,19 +16,19 @@ export default ({ mode }) => {
     server: {
       proxy: {
         '/api': {
-          target: 'http://localhost:8000',
+          target: 'https://sel2-2.ugent.be',
           changeOrigin: true,
         },
         '/admin': {
-          target: 'http://localhost:8000',
+          target: 'https://sel2-2.ugent.be',
           changeOrigin: true,
         },
         '/static': {
-          target: 'http://localhost:8000',
+          target: 'https://sel2-2.ugent.be',
           changeOrigin: true,
         },
         '/media': {
-          target: 'http://localhost:8000',
+          target: 'https://sel2-2.ugent.be',
           changeOrigin: true,
         },
       },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,19 +16,19 @@ export default ({ mode }) => {
     server: {
       proxy: {
         '/api': {
-          target: 'https://sel2-2.ugent.be',
+          target: 'http://localhost:8000',
           changeOrigin: true,
         },
         '/admin': {
-          target: 'https://sel2-2.ugent.be',
+          target: 'http://localhost:8000',
           changeOrigin: true,
         },
         '/static': {
-          target: 'https://sel2-2.ugent.be',
+          target: 'http://localhost:8000',
           changeOrigin: true,
         },
         '/media': {
-          target: 'https://sel2-2.ugent.be',
+          target: 'http://localhost:8000',
           changeOrigin: true,
         },
       },


### PR DESCRIPTION
The “Page Not Found” URL for series is /not-found, not /404 like the rest. I've fixed this so that they all redirect to /404. I've also fixed it so that if a route doesn't exist, you're redirected to /404; before, the URL would just stay the same.