### PR TITLE
show count bug fix

### DIFF
--- a/backend/apps/core/admin_filters.py
+++ b/backend/apps/core/admin_filters.py
@@ -139,7 +139,7 @@ class SearchableMultiSelectFilter(SimpleListFilter):
 
         return counts
 
-    def choices(self, changelist: any):
+    def choices(self, changelist: any) -> any:
         """Return minimal choices without forcing facet aggregation.
 
         The custom multiselect template renders options independently, so we

--- a/backend/apps/core/admin_filters.py
+++ b/backend/apps/core/admin_filters.py
@@ -32,6 +32,8 @@ Typical usage in a ModelAdmin:
 """
 
 from django.contrib.admin import SimpleListFilter
+from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 
 class SearchableMultiSelectFilter(SimpleListFilter):
@@ -61,6 +63,7 @@ class SearchableMultiSelectFilter(SimpleListFilter):
     clear_search_url = "?"
     reset_url = "?"
     is_open = False
+    max_facet_options = 1500
 
     def __init__(self, request: any, params: dict, model: any, model_admin: any) -> None:
         """Initialize filter state and sanitize custom query params.
@@ -110,6 +113,44 @@ class SearchableMultiSelectFilter(SimpleListFilter):
     def expected_parameters(self) -> list[str]:
         """Declare all query params this filter owns."""
         return [self.parameter_name, self.search_param, self.open_param]
+
+    def get_facet_counts(self, pk_attname: str, filtered_qs: any) -> dict[str, models.Count]:
+        """Build Django facet annotations for the current multiselect options.
+
+        Django's admin facet support expects a single aggregate query that
+        returns one count per choice. That is the correct integration point
+        for the custom checkbox filter, because the admin can then decide when
+        to add counts via its own ``_facets`` toggle.
+        """
+        if len(self.lookup_choices) > self.max_facet_options:
+            # Prevent PostgreSQL "target list can have at most 1664 entries".
+            return {}
+
+        original_selected_values = self.selected_values
+        counts: dict[str, models.Count] = {}
+
+        try:
+            for index, (choice_value, _choice_label) in enumerate(self.lookup_choices):
+                self.selected_values = (str(choice_value),)
+                lookup_qs = self.filter_queryset(filtered_qs)
+                counts[f"{index}__c"] = models.Count(pk_attname, filter=models.Q(pk__in=lookup_qs))
+        finally:
+            self.selected_values = original_selected_values
+
+        return counts
+
+    def choices(self, changelist: any):
+        """Return minimal choices without forcing facet aggregation.
+
+        The custom multiselect template renders options independently, so we
+        avoid Django's default facet query here to prevent oversized target
+        lists when many options are present.
+        """
+        yield {
+            "selected": not self.selected_values,
+            "query_string": changelist.get_query_string(remove=[self.parameter_name]),
+            "display": _("All"),
+        }
 
     def get_option_queryset(self) -> list[tuple[str, str]]:
         """Return list of selectable options as ``[(value, label), ...]``."""

--- a/backend/apps/core/templatetags/admin_dashboard.py
+++ b/backend/apps/core/templatetags/admin_dashboard.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 from django import template
 from django.contrib import admin
@@ -109,3 +110,33 @@ def dashboard_cards(context: dict) -> list[dict[str, str | int]]:
         )
 
     return cards
+
+
+def _build_multiselect_options(cl: Any, spec: Any) -> list[dict[str, Any]]:
+    """Return renderable option data for a searchable multiselect filter.
+
+    Counts are obtained through Django's facet queryset machinery so the
+    admin's ``_facets`` toggle controls when they are calculated.
+    """
+    facet_counts: dict[str, Any] = {}
+    if getattr(cl, "add_facets", False):
+        facet_counts = spec.get_facet_queryset(cl)
+
+    options: list[dict[str, Any]] = []
+    for index, (value, label) in enumerate(spec.lookup_choices):
+        options.append(
+            {
+                "value": value,
+                "label": label,
+                "selected": value in spec.selected_values,
+                "count": facet_counts.get(f"{index}__c"),
+            }
+        )
+
+    return options
+
+
+@register.simple_tag
+def multiselect_options(cl: Any, spec: Any) -> list[dict[str, Any]]:
+    """Return option dictionaries for the multiselect filter template."""
+    return _build_multiselect_options(cl, spec)

--- a/backend/templates/multiselect_search.html
+++ b/backend/templates/multiselect_search.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n admin_dashboard %}
 <style>
   .generic-multiselect-filter {
     box-sizing: border-box;
@@ -55,7 +55,7 @@
         value="{{ spec.search_value }}"
         list="{{ spec.parameter_name }}_suggestions"
         autocomplete="off"
-        placeholder="{% trans 'Search in list...' %}"
+        placeholder="{% trans 'Search in list (English name)...' %}"
         aria-label="{% trans 'Search in list' %}"
         class="vTextField"
         style="flex:1 1 auto; min-width:0; margin:0;"
@@ -72,20 +72,21 @@
     </datalist>
 
     <div style="max-height: 220px; overflow: auto; margin:0 0 6px;" data-multiselect-options>
-      {% if spec.lookup_choices %}
+      {% multiselect_options cl spec as multiselect_options %}
+      {% if multiselect_options %}
         {% if spec.selected_values %}
           <div style="margin:4px 0; color:#666; font-size:11px; text-transform:uppercase; letter-spacing:.02em;">{% trans "Selected" %}</div>
-          {% for val, label in spec.lookup_choices %}
-            {% if val in spec.selected_values %}
-              <div data-option-row data-selected-row="1" data-option-label="{{ label|lower }}" style="margin:0 0 2px;">
+          {% for option in multiselect_options %}
+            {% if option.selected %}
+              <div data-option-row data-selected-row="1" data-option-label="{{ option.label|lower }}" style="margin:0 0 2px;">
                 <label style="display:flex; flex-wrap:nowrap; gap:6px; align-items:flex-start; cursor:pointer; min-width:0; width:100%;">
                   <input
                     type="checkbox"
                     name="{{ spec.parameter_name }}"
-                    value="{{ val }}"
+                    value="{{ option.value }}"
                     checked
                   >
-                  <span style="flex:1 1 auto; min-width:0; word-break:break-word; overflow-wrap:anywhere; white-space:normal;">{{ label }}</span>
+                  <span style="flex:1 1 auto; min-width:0; word-break:break-word; overflow-wrap:anywhere; white-space:normal;">{{ option.label }}{% if cl.add_facets and option.count is not None %} ({{ option.count }}){% endif %}</span>
                 </label>
               </div>
             {% endif %}
@@ -95,16 +96,16 @@
         {% endif %}
 
         <div style="margin:4px 0; color:#666; font-size:11px; text-transform:uppercase; letter-spacing:.02em;">{% trans "Available" %}</div>
-        {% for val, label in spec.lookup_choices %}
-          {% if val not in spec.selected_values %}
-            <div data-option-row data-option-label="{{ label|lower }}" style="margin:0 0 2px;">
+        {% for option in multiselect_options %}
+          {% if not option.selected %}
+            <div data-option-row data-option-label="{{ option.label|lower }}" style="margin:0 0 2px;">
               <label>
                 <input
                   type="checkbox"
                   name="{{ spec.parameter_name }}"
-                  value="{{ val }}"
+                  value="{{ option.value }}"
                 >
-                <span>{{ label }}</span>
+                <span>{{ option.label }}{% if cl.add_facets and option.count is not None %} ({{ option.count }}){% endif %}</span>
               </label>
             </div>
           {% endif %}

--- a/backend/tests/core/test_admin_dashboard_templatetag.py
+++ b/backend/tests/core/test_admin_dashboard_templatetag.py
@@ -134,3 +134,51 @@ class TestAdminDashboardTemplateTag(TestCase):
         assert cards[0]["count"] == 2
         assert cards[0]["url"] == reverse("admin:productions_production_changelist")
         assert cards[0]["add_url"] == reverse("admin:productions_production_add")
+
+    def test_build_multiselect_options_without_facets(self) -> None:
+        class DummySpec:
+            lookup_choices = [("a", "Alpha"), ("b", "Beta")]
+            selected_values = ("b",)
+
+        class DummyChangeList:
+            add_facets = False
+
+        options = admin_dashboard._build_multiselect_options(DummyChangeList(), DummySpec())
+
+        assert options == [
+            {"value": "a", "label": "Alpha", "selected": False, "count": None},
+            {"value": "b", "label": "Beta", "selected": True, "count": None},
+        ]
+
+    def test_build_multiselect_options_with_facets(self) -> None:
+        class DummySpec:
+            lookup_choices = [("a", "Alpha"), ("b", "Beta")]
+            selected_values = ()
+
+            def get_facet_queryset(self, _cl):
+                return {"0__c": 4, "1__c": 2}
+
+        class DummyChangeList:
+            add_facets = True
+
+        options = admin_dashboard._build_multiselect_options(DummyChangeList(), DummySpec())
+
+        assert options == [
+            {"value": "a", "label": "Alpha", "selected": False, "count": 4},
+            {"value": "b", "label": "Beta", "selected": False, "count": 2},
+        ]
+
+    def test_multiselect_options_tag_passthrough(self) -> None:
+        class DummySpec:
+            lookup_choices = [("a", "Alpha")]
+            selected_values = ()
+
+            def get_facet_queryset(self, _cl):
+                return {"0__c": 1}
+
+        class DummyChangeList:
+            add_facets = True
+
+        assert admin_dashboard.multiselect_options(DummyChangeList(), DummySpec()) == [
+            {"value": "a", "label": "Alpha", "selected": False, "count": 1}
+        ]

--- a/backend/tests/core/test_admin_filters.py
+++ b/backend/tests/core/test_admin_filters.py
@@ -78,6 +78,37 @@ class TestSearchableMultiSelectFilter(TestCase):
         filter_instance, _ = self._build_filter("code=nl&code=en")
         assert filter_instance.value() == ["nl", "en"]
 
+    def test_get_facet_counts_returns_annotations(self) -> None:
+        filter_instance, _ = self._build_filter("")
+        counts = filter_instance.get_facet_counts(Language._meta.pk.attname, Language.objects.order_by("code"))
+
+        assert set(counts) == {"0__c", "1__c"}
+        assert Language.objects.order_by("code").aggregate(**counts) == {"0__c": 1, "1__c": 1}
+
+    def test_get_facet_counts_caps_when_too_many_options(self) -> None:
+        filter_instance, _ = self._build_filter("")
+        filter_instance.lookup_choices = [
+            (str(index), f"Option {index}") for index in range(filter_instance.max_facet_options + 1)
+        ]
+
+        counts = filter_instance.get_facet_counts(Language._meta.pk.attname, Language.objects.order_by("code"))
+
+        assert counts == {}
+
+    def test_choices_returns_all_entry(self) -> None:
+        filter_instance, _ = self._build_filter("")
+
+        class DummyChangeList:
+            def get_query_string(self, *args, **kwargs):
+                return "?"
+
+        choices = list(filter_instance.choices(DummyChangeList()))
+        assert choices == [{"selected": True, "query_string": "?", "display": "All"}]
+
+        filter_instance.selected_values = ("nl",)
+        choices = list(filter_instance.choices(DummyChangeList()))
+        assert choices == [{"selected": False, "query_string": "?", "display": "All"}]
+
     def test_base_get_option_queryset_raises_not_implemented(self) -> None:
         with pytest.raises(NotImplementedError):
             SearchableMultiSelectFilter.get_option_queryset(object())

--- a/backend/tests/core/test_admin_filters.py
+++ b/backend/tests/core/test_admin_filters.py
@@ -99,7 +99,7 @@ class TestSearchableMultiSelectFilter(TestCase):
         filter_instance, _ = self._build_filter("")
 
         class DummyChangeList:
-            def get_query_string(self, *args, **kwargs):
+            def get_query_string(self, **_kwargs):
                 return "?"
 
         choices = list(filter_instance.choices(DummyChangeList()))


### PR DESCRIPTION
This PR fixes a bug that the show count button in the cms filter panel leads to an error 500. This bug only occurred on the production page because it has a custom filter panel.

This bug should now be fixed, test it by opening the production list page and press the show count button. You should see the count appear for the attendance mode and performer type filters.

